### PR TITLE
Add partial sync support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.6.1-0.20210608092034-e4f40bc3a685
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.6
-	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-graphsync v0.8.1-rc1
 	github.com/ipfs/go-log/v2 v2.1.3
 	github.com/ipld/go-ipld-prime v0.11.1-0.20210814231128-df94e6a99727

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.6.1-0.20210608092034-e4f40bc3a685
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.6
+	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-graphsync v0.8.1-rc1
+	github.com/ipfs/go-log/v2 v2.1.3
 	github.com/ipld/go-ipld-prime v0.11.1-0.20210814231128-df94e6a99727
 	github.com/libp2p/go-libp2p v0.14.4
 	github.com/libp2p/go-libp2p-core v0.8.6
@@ -16,3 +18,7 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210713220151-be142a5ae1a8
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
+
+// TODO: Remove when https://github.com/ipld/go-ipld-prime/pull/229 is merged
+// and upgrade
+replace github.com/ipld/go-ipld-prime => github.com/adlrocha/go-ipld-prime v0.11.1-0.20210818075804-6bb6d8b2afce

--- a/go.sum
+++ b/go.sum
@@ -225,7 +225,6 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -355,7 +354,6 @@ github.com/ipfs/go-ds-badger v0.2.6/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6
 github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
-github.com/ipfs/go-ds-leveldb v0.4.2 h1:QmQoAJ9WkPMUfBLnu1sBVy0xWWlJPg0m4kRAiJL9iaw=
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
 github.com/ipfs/go-graphsync v0.8.1-rc1 h1:dmLAym2INCMm86HnDH8LXaWRpSw8Ltq9px1AzOPbGsE=
 github.com/ipfs/go-graphsync v0.8.1-rc1/go.mod h1:/8Plco5WTSAydRzNrMTgBMgWY/NFC5x9kBXPLFU5d3M=
@@ -1024,7 +1022,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/adlrocha/go-ipld-prime v0.11.1-0.20210818075804-6bb6d8b2afce h1:u5KwaQ1uI3WfhZ5hm5RByV9JpdnFPaa3mxnGbpomna8=
+github.com/adlrocha/go-ipld-prime v0.11.1-0.20210818075804-6bb6d8b2afce/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -223,6 +225,7 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -352,6 +355,7 @@ github.com/ipfs/go-ds-badger v0.2.6/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6
 github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
+github.com/ipfs/go-ds-leveldb v0.4.2 h1:QmQoAJ9WkPMUfBLnu1sBVy0xWWlJPg0m4kRAiJL9iaw=
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
 github.com/ipfs/go-graphsync v0.8.1-rc1 h1:dmLAym2INCMm86HnDH8LXaWRpSw8Ltq9px1AzOPbGsE=
 github.com/ipfs/go-graphsync v0.8.1-rc1/go.mod h1:/8Plco5WTSAydRzNrMTgBMgWY/NFC5x9kBXPLFU5d3M=
@@ -425,10 +429,6 @@ github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipld/go-codec-dagpb v1.2.0 h1:2umV7ud8HBMkRuJgd8gXw95cLhwmcYrihS3cQEy9zpI=
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
-github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
-github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
-github.com/ipld/go-ipld-prime v0.11.1-0.20210814231128-df94e6a99727 h1:0B+JIZkn2/JT86eBnFN3Psabj++hHgEFHTjvfh3rMf8=
-github.com/ipld/go-ipld-prime v0.11.1-0.20210814231128-df94e6a99727/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
@@ -907,7 +907,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
-github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e h1:ZOcivgkkFRnjfoTcGsDq3UQYiBmekwLA+qg0OjyB/ls=
 github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
@@ -1025,6 +1024,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/legs_test.go
+++ b/legs_test.go
@@ -16,8 +16,6 @@ import (
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	selectorbuilder "github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/multiformats/go-multicodec"
@@ -64,11 +62,7 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host,
 		t.Fatal(err)
 	}
 	dstLnkS := mkLinkSystem(dstStore)
-	// Fetch-all recursively selector
-	np := basicnode.Prototype__Any{}
-	ssb := selectorbuilder.NewSelectorSpecBuilder(np)
-	sn := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-	ls, err := legs.NewSubscriber(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, sn, nil)
+	ls, err := legs.NewSubscriber(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/selector.go
+++ b/selector.go
@@ -1,0 +1,53 @@
+package legs
+
+import (
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/fluent"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	selectorbuilder "github.com/ipld/go-ipld-prime/traversal/selector/builder"
+)
+
+// ExploreRecursiveWithStop builds a selector that recursively syncs a DAG
+// until the link stopLnk is seen. It prevents from having to sync DAGs from
+// scratch with every update.
+func ExploreRecursiveWithStop(limit selector.RecursionLimit, sequence selectorbuilder.SelectorSpec, stopLnk ipld.Link) ipld.Node {
+	np := basicnode.Prototype__Map{}
+	return fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
+		// RecursionLimit
+		na.AssembleEntry(selector.SelectorKey_ExploreRecursive).CreateMap(3, func(na fluent.MapAssembler) {
+			na.AssembleEntry(selector.SelectorKey_Limit).CreateMap(1, func(na fluent.MapAssembler) {
+				switch limit.Mode() {
+				case selector.RecursionLimit_Depth:
+					na.AssembleEntry(selector.SelectorKey_LimitDepth).AssignInt(limit.Depth())
+				case selector.RecursionLimit_None:
+					na.AssembleEntry(selector.SelectorKey_LimitNone).CreateMap(0, func(na fluent.MapAssembler) {})
+				default:
+					panic("Unsupported recursion limit type")
+				}
+			})
+			// Sequence
+			na.AssembleEntry(selector.SelectorKey_Sequence).AssignNode(sequence.Node())
+
+			// Stop condition
+			if stopLnk != nil {
+				cond := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
+					na.AssembleEntry(string(selector.ConditionMode_Link)).AssignLink(stopLnk)
+				})
+				na.AssembleEntry(selector.SelectorKey_StopAt).AssignNode(cond)
+			}
+		})
+	})
+
+}
+
+// LegSelector is a convenient function that  returns the selector
+// used by leg subscribers
+func legSelector(stopLnk ipld.Link) ipld.Node {
+	np := basicnode.Prototype__Any{}
+	ssb := selectorbuilder.NewSelectorSpecBuilder(np)
+	return ExploreRecursiveWithStop(
+		selector.RecursionLimitNone(),
+		ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
+		stopLnk)
+}

--- a/sync_test.go
+++ b/sync_test.go
@@ -1,0 +1,207 @@
+package legs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	leveldb "github.com/ipfs/go-ds-leveldb"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/fluent"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/multiformats/go-multicodec"
+)
+
+func mkTestHost() host.Host {
+	h, _ := libp2p.New(context.Background(), libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
+	return h
+}
+
+func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.StorageReadOpener = func(lctx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
+		c := lnk.(cidlink.Link).Cid
+		val, err := ds.Get(datastore.NewKey(c.String()))
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(val), nil
+	}
+	lsys.StorageWriteOpener = func(_ ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
+		buf := bytes.NewBuffer(nil)
+		return buf, func(lnk ipld.Link) error {
+			c := lnk.(cidlink.Link).Cid
+			return ds.Put(datastore.NewKey(c.String()), buf.Bytes())
+		}, nil
+	}
+	return lsys
+}
+
+func mkChain(lsys ipld.LinkSystem) (ipld.Node, []ipld.Link) {
+	_, leafAlphaLnk := encode(lsys, basicnode.NewString("alpha"))
+	_, leafBetaLnk := encode(lsys, basicnode.NewString("beta"))
+	_, middleMapNodeLnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
+		na.AssembleEntry("foo").AssignBool(true)
+		na.AssembleEntry("bar").AssignBool(false)
+		na.AssembleEntry("nested").CreateMap(2, func(na fluent.MapAssembler) {
+			na.AssembleEntry("alink").AssignLink(leafAlphaLnk)
+			na.AssembleEntry("nonlink").AssignString("zoo")
+		})
+	}))
+	_, middleListNodeLnk := encode(lsys, fluent.MustBuildList(basicnode.Prototype__List{}, 4, func(na fluent.ListAssembler) {
+		na.AssembleValue().AssignLink(leafAlphaLnk)
+		na.AssembleValue().AssignLink(leafAlphaLnk)
+		na.AssembleValue().AssignLink(leafBetaLnk)
+		na.AssembleValue().AssignLink(leafAlphaLnk)
+	}))
+
+	_, ch1Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("linkedList").AssignLink(middleListNodeLnk)
+	}))
+	_, ch2Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("linkedMap").AssignLink(middleMapNodeLnk)
+		na.AssembleEntry("ch1").AssignLink(ch1Lnk)
+	}))
+	_, ch3Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("linkedString").AssignLink(leafAlphaLnk)
+		na.AssembleEntry("ch2").AssignLink(ch2Lnk)
+	}))
+
+	headNode, headLnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("plain").AssignString("olde string")
+		na.AssembleEntry("ch3").AssignLink(ch3Lnk)
+	}))
+	return headNode, []ipld.Link{headLnk, ch3Lnk, ch2Lnk, ch1Lnk}
+}
+
+// encode hardcodes some encoding choices for ease of use in fixture generation;
+// just gimme a link and stuff the bytes in a map.
+// (also return the node again for convenient assignment.)
+func encode(lsys ipld.LinkSystem, n ipld.Node) (ipld.Node, ipld.Link) {
+	lp := cidlink.LinkPrototype{
+		Prefix: cid.Prefix{
+			Version:  1,
+			Codec:    uint64(multicodec.DagJson),
+			MhType:   uint64(multicodec.Sha2_256),
+			MhLength: 16,
+		},
+	}
+
+	lnk, err := lsys.Store(ipld.LinkContext{}, lp, n)
+	if err != nil {
+		panic(err)
+	}
+	return n, lnk
+}
+
+func mkLevelDs(t *testing.T) datastore.Batching {
+	tmpDir, err := ioutil.TempDir("", "go-legs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dstore, err := leveldb.NewDatastore(tmpDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dstore
+}
+func TestLatestSync(t *testing.T) {
+	// NOTE: In order to aviod parallel read/write (which makes the test flaky), we need
+	// to use a concurrency-friendly datastore like levelDB
+	srcStore := mkLevelDs(t)
+	dstStore := mkLevelDs(t)
+	srcHost := mkTestHost()
+	srcLnkS := mkLinkSystem(srcStore)
+	lp, err := NewPublisher(context.Background(), srcStore, srcHost, "legs/testtopic", srcLnkS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstHost := mkTestHost()
+	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
+	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
+		t.Fatal(err)
+	}
+	dstLnkS := mkLinkSystem(dstStore)
+	ls, err := NewSubscriber(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// per https://github.com/libp2p/go-libp2p-pubsub/blob/e6ad80cf4782fca31f46e3a8ba8d1a450d562f49/gossipsub_test.go#L103
+	// we don't seem to have a way to manually trigger needed gossip-sub heartbeats for mesh establishment.
+	time.Sleep(time.Second)
+
+	watcher, cncl := ls.OnChange()
+
+	_, chainLnks := mkChain(srcLnkS)
+
+	defer func() {
+		cncl()
+		lp.Close(context.Background())
+		ls.Close(context.Background())
+	}()
+
+	newUpdateTest(t, lp, ls, watcher, chainLnks[3])
+	newUpdateTest(t, lp, ls, watcher, chainLnks[2])
+	newUpdateTest(t, lp, ls, watcher, chainLnks[1])
+	newUpdateTest(t, lp, ls, watcher, chainLnks[0])
+}
+
+func newUpdateTest(t *testing.T, lp LegPublisher, ls LegSubscriber, watcher chan cid.Cid, lnk ipld.Link) {
+	if err := lp.UpdateRoot(context.Background(), lnk.(cidlink.Link).Cid); err != nil {
+		t.Fatal(err)
+	}
+
+	lsT := ls.(*legSubscriber)
+	select {
+	case <-time.After(time.Second * 2):
+		t.Fatal("timed out waiting for sync to propogate")
+	case downstream := <-watcher:
+		if !downstream.Equals(lnk.(cidlink.Link).Cid) {
+			t.Fatalf("sync'd sid unexpected %s vs %s", downstream, lnk)
+		}
+		if _, err := lsT.ds.Get(datastore.NewKey(downstream.String())); err != nil {
+			t.Fatalf("data not in receiver store: %v", err)
+		}
+	}
+	if lsT.latestSync.(cidlink.Link).Cid != lnk.(cidlink.Link).Cid {
+		t.Fatal("latestSync not updated correctly", lsT.latestSync)
+	}
+}
+
+// NOTE: This test may print datatransfer migration related errors. As long as this test
+// pass you don't need to worry about it. However, if it is bothering you, comment or remove
+// this test. In the end this a straightforward test which checks if we are initializing
+// a partially synced subscriber correctly (which is quite straightforward).
+func TestPartiallySynced(t *testing.T) {
+	dstStore := datastore.NewMapDatastore()
+	dstHost := mkTestHost()
+	dstLnkS := mkLinkSystem(dstStore)
+	_, chainLnks := mkChain(dstLnkS)
+	ls, err := NewSubscriberPartiallySynced(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil, chainLnks[0].(cidlink.Link).Cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ls.(*legSubscriber).latestSync.(cidlink.Link).Cid != chainLnks[0].(cidlink.Link).Cid {
+		t.Fatal("partial synced not set correctly")
+	}
+
+	ls, err = NewSubscriberPartiallySynced(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil, cid.Undef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ls.(*legSubscriber).latestSync != nil {
+		t.Fatal("cidUndef should set latestSync to nil to avoid errors")
+	}
+
+}

--- a/sync_test.go
+++ b/sync_test.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
-	leveldb "github.com/ipfs/go-ds-leveldb"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -18,6 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/multiformats/go-multicodec"
+	testds "github.com/willscott/go-legs/test/datastore"
 )
 
 func mkTestHost() host.Host {
@@ -45,7 +44,9 @@ func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 	return lsys
 }
 
-func mkChain(lsys ipld.LinkSystem) (ipld.Node, []ipld.Link) {
+// Return the chain with all nodes or just half of it for testing
+func mkChain(lsys ipld.LinkSystem, full bool) []ipld.Link {
+	out := make([]ipld.Link, 4)
 	_, leafAlphaLnk := encode(lsys, basicnode.NewString("alpha"))
 	_, leafBetaLnk := encode(lsys, basicnode.NewString("beta"))
 	_, middleMapNodeLnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
@@ -66,20 +67,25 @@ func mkChain(lsys ipld.LinkSystem) (ipld.Node, []ipld.Link) {
 	_, ch1Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
 		na.AssembleEntry("linkedList").AssignLink(middleListNodeLnk)
 	}))
+	out[3] = ch1Lnk
 	_, ch2Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
 		na.AssembleEntry("linkedMap").AssignLink(middleMapNodeLnk)
 		na.AssembleEntry("ch1").AssignLink(ch1Lnk)
 	}))
-	_, ch3Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
-		na.AssembleEntry("linkedString").AssignLink(leafAlphaLnk)
-		na.AssembleEntry("ch2").AssignLink(ch2Lnk)
-	}))
-
-	headNode, headLnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
-		na.AssembleEntry("plain").AssignString("olde string")
-		na.AssembleEntry("ch3").AssignLink(ch3Lnk)
-	}))
-	return headNode, []ipld.Link{headLnk, ch3Lnk, ch2Lnk, ch1Lnk}
+	out[2] = ch2Lnk
+	if full {
+		_, ch3Lnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+			na.AssembleEntry("linkedString").AssignLink(leafAlphaLnk)
+			na.AssembleEntry("ch2").AssignLink(ch2Lnk)
+		}))
+		out[1] = ch3Lnk
+		_, headLnk := encode(lsys, fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+			na.AssembleEntry("plain").AssignString("olde string")
+			na.AssembleEntry("ch3").AssignLink(ch3Lnk)
+		}))
+		out[0] = headLnk
+	}
+	return out
 }
 
 // encode hardcodes some encoding choices for ease of use in fixture generation;
@@ -102,22 +108,9 @@ func encode(lsys ipld.LinkSystem, n ipld.Node) (ipld.Node, ipld.Link) {
 	return n, lnk
 }
 
-func mkLevelDs(t *testing.T) datastore.Batching {
-	tmpDir, err := ioutil.TempDir("", "go-legs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dstore, err := leveldb.NewDatastore(tmpDir, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dstore
-}
-func TestLatestSync(t *testing.T) {
-	// NOTE: In order to aviod parallel read/write (which makes the test flaky), we need
-	// to use a concurrency-friendly datastore like levelDB
-	srcStore := mkLevelDs(t)
-	dstStore := mkLevelDs(t)
+func TestLatestSyncSuccess(t *testing.T) {
+	srcStore := testds.NewMapDatastore()
+	dstStore := testds.NewMapDatastore()
 	srcHost := mkTestHost()
 	srcLnkS := mkLinkSystem(srcStore)
 	lp, err := NewPublisher(context.Background(), srcStore, srcHost, "legs/testtopic", srcLnkS)
@@ -143,7 +136,8 @@ func TestLatestSync(t *testing.T) {
 
 	watcher, cncl := ls.OnChange()
 
-	_, chainLnks := mkChain(srcLnkS)
+	// Store the whole chain in source node
+	chainLnks := mkChain(srcLnkS, true)
 
 	defer func() {
 		cncl()
@@ -151,57 +145,133 @@ func TestLatestSync(t *testing.T) {
 		ls.Close(context.Background())
 	}()
 
-	newUpdateTest(t, lp, ls, watcher, chainLnks[3])
-	newUpdateTest(t, lp, ls, watcher, chainLnks[2])
-	newUpdateTest(t, lp, ls, watcher, chainLnks[1])
-	newUpdateTest(t, lp, ls, watcher, chainLnks[0])
+	newUpdateTest(t, lp, ls, watcher, chainLnks[2], false, chainLnks[2].(cidlink.Link).Cid)
+	newUpdateTest(t, lp, ls, watcher, chainLnks[1], false, chainLnks[1].(cidlink.Link).Cid)
+	newUpdateTest(t, lp, ls, watcher, chainLnks[0], false, chainLnks[0].(cidlink.Link).Cid)
 }
 
-func newUpdateTest(t *testing.T, lp LegPublisher, ls LegSubscriber, watcher chan cid.Cid, lnk ipld.Link) {
+func TestPartialSync(t *testing.T) {
+	srcStore := testds.NewMapDatastore()
+	dstStore := testds.NewMapDatastore()
+	srcHost := mkTestHost()
+	srcLnkS := mkLinkSystem(srcStore)
+	lp, err := NewPublisher(context.Background(), srcStore, srcHost, "legs/testtopic", srcLnkS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstHost := mkTestHost()
+	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
+	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
+		t.Fatal(err)
+	}
+	dstLnkS := mkLinkSystem(dstStore)
+	ls, err := NewSubscriber(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// per https://github.com/libp2p/go-libp2p-pubsub/blob/e6ad80cf4782fca31f46e3a8ba8d1a450d562f49/gossipsub_test.go#L103
+	// we don't seem to have a way to manually trigger needed gossip-sub heartbeats for mesh establishment.
+	time.Sleep(time.Second)
+
+	watcher, cncl := ls.OnChange()
+
+	// Store the whole chain in source node
+	chainLnks := mkChain(srcLnkS, true)
+	// Store half of the chain already in destination
+	// to simulate the partial sync.
+	mkChain(dstLnkS, true)
+
+	defer func() {
+		cncl()
+		lp.Close(context.Background())
+		ls.Close(context.Background())
+	}()
+
+	newUpdateTest(t, lp, ls, watcher, chainLnks[1], false, chainLnks[1].(cidlink.Link).Cid)
+	newUpdateTest(t, lp, ls, watcher, chainLnks[0], false, chainLnks[0].(cidlink.Link).Cid)
+}
+
+func TestLatestSyncFailure(t *testing.T) {
+	srcStore := testds.NewMapDatastore()
+	dstStore := testds.NewMapDatastore()
+	srcHost := mkTestHost()
+	srcLnkS := mkLinkSystem(srcStore)
+	lp, err := NewPublisher(context.Background(), srcStore, srcHost, "legs/testtopic", srcLnkS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstHost := mkTestHost()
+	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
+	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
+		t.Fatal(err)
+	}
+	chainLnks := mkChain(srcLnkS, true)
+	dstLnkS := mkLinkSystem(dstStore)
+	ls, err := NewSubscriberPartiallySynced(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil, chainLnks[3].(cidlink.Link).Cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// per https://github.com/libp2p/go-libp2p-pubsub/blob/e6ad80cf4782fca31f46e3a8ba8d1a450d562f49/gossipsub_test.go#L103
+	// we don't seem to have a way to manually trigger needed gossip-sub heartbeats for mesh establishment.
+	time.Sleep(time.Second)
+
+	watcher, cncl := ls.OnChange()
+
+	defer func() {
+		cncl()
+		lp.Close(context.Background())
+		ls.Close(context.Background())
+	}()
+
+	// The other end doesn't have the data
+	newUpdateTest(t, lp, ls, watcher, cidlink.Link{Cid: cid.Undef}, true, chainLnks[3].(cidlink.Link).Cid)
+
+	dstStore = testds.NewMapDatastore()
+	ls, err = NewSubscriberPartiallySynced(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil, chainLnks[3].(cidlink.Link).Cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We are not able to run the full exchange
+	newUpdateTest(t, lp, ls, watcher, chainLnks[2], true, chainLnks[3].(cidlink.Link).Cid)
+}
+
+func newUpdateTest(t *testing.T, lp LegPublisher, ls LegSubscriber, watcher chan cid.Cid, lnk ipld.Link, withFailure bool, expectedSync cid.Cid) {
 	if err := lp.UpdateRoot(context.Background(), lnk.(cidlink.Link).Cid); err != nil {
 		t.Fatal(err)
 	}
 
 	lsT := ls.(*legSubscriber)
-	select {
-	case <-time.After(time.Second * 2):
-		t.Fatal("timed out waiting for sync to propogate")
-	case downstream := <-watcher:
-		if !downstream.Equals(lnk.(cidlink.Link).Cid) {
-			t.Fatalf("sync'd sid unexpected %s vs %s", downstream, lnk)
+
+	// If failure latestSync shouldn't be updated
+	if withFailure {
+		select {
+		case <-time.After(time.Second * 2):
+			if lsT.latestSync.(cidlink.Link).Cid != expectedSync {
+				t.Fatal("latestSync shouldn't have been updated", lsT.latestSync)
+			}
+		case <-watcher:
+			t.Fatal("no exchange should have been performed")
 		}
-		if _, err := lsT.ds.Get(datastore.NewKey(downstream.String())); err != nil {
-			t.Fatalf("data not in receiver store: %v", err)
+	} else {
+		select {
+		case <-time.After(time.Second * 2):
+			t.Fatal("timed out waiting for sync to propogate")
+		case downstream := <-watcher:
+			if !downstream.Equals(lnk.(cidlink.Link).Cid) {
+				t.Fatalf("sync'd sid unexpected %s vs %s", downstream, lnk)
+			}
+			if _, err := lsT.ds.Get(datastore.NewKey(downstream.String())); err != nil {
+				t.Fatalf("data not in receiver store: %v", err)
+			}
+		}
+		if lsT.latestSync.(cidlink.Link).Cid != expectedSync {
+			t.Fatal("latestSync not updated correctly", lsT.latestSync)
 		}
 	}
-	if lsT.latestSync.(cidlink.Link).Cid != lnk.(cidlink.Link).Cid {
-		t.Fatal("latestSync not updated correctly", lsT.latestSync)
-	}
-}
-
-// NOTE: This test may print datatransfer migration related errors. As long as this test
-// pass you don't need to worry about it. However, if it is bothering you, comment or remove
-// this test. In the end this a straightforward test which checks if we are initializing
-// a partially synced subscriber correctly (which is quite straightforward).
-func TestPartiallySynced(t *testing.T) {
-	dstStore := datastore.NewMapDatastore()
-	dstHost := mkTestHost()
-	dstLnkS := mkLinkSystem(dstStore)
-	_, chainLnks := mkChain(dstLnkS)
-	ls, err := NewSubscriberPartiallySynced(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil, chainLnks[0].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ls.(*legSubscriber).latestSync.(cidlink.Link).Cid != chainLnks[0].(cidlink.Link).Cid {
-		t.Fatal("partial synced not set correctly")
-	}
-
-	ls, err = NewSubscriberPartiallySynced(context.Background(), dstStore, dstHost, "legs/testtopic", dstLnkS, nil, cid.Undef)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ls.(*legSubscriber).latestSync != nil {
-		t.Fatal("cidUndef should set latestSync to nil to avoid errors")
-	}
-
 }

--- a/test/datastore/datastore.go
+++ b/test/datastore/datastore.go
@@ -1,0 +1,100 @@
+package datastore
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+// Here are some basic datastore implementations.
+
+// MapDatastore uses a standard Go map for internal storage.
+type MapDatastore struct {
+	values map[datastore.Key][]byte
+	lk     sync.RWMutex
+}
+
+// NewMapDatastore constructs a MapDatastore. It is _not_ thread-safe by
+// default, wrap using sync.MutexWrap if you need thread safety (the answer here
+// is usually yes).
+func NewMapDatastore() (d *MapDatastore) {
+	return &MapDatastore{
+		values: make(map[datastore.Key][]byte),
+	}
+}
+
+// Put implements Datastore.Put
+func (d *MapDatastore) Put(key datastore.Key, value []byte) (err error) {
+	d.lk.Lock()
+	defer d.lk.Unlock()
+	d.values[key] = value
+	return nil
+}
+
+// Sync implements Datastore.Sync
+func (d *MapDatastore) Sync(prefix datastore.Key) error {
+	return nil
+}
+
+// Get implements Datastore.Get
+func (d *MapDatastore) Get(key datastore.Key) (value []byte, err error) {
+	d.lk.RLock()
+	defer d.lk.RUnlock()
+	val, found := d.values[key]
+	if !found {
+		return nil, datastore.ErrNotFound
+	}
+	return val, nil
+}
+
+// Has implements Datastore.Has
+func (d *MapDatastore) Has(key datastore.Key) (exists bool, err error) {
+	d.lk.RLock()
+	defer d.lk.RUnlock()
+	_, found := d.values[key]
+	return found, nil
+}
+
+// GetSize implements Datastore.GetSize
+func (d *MapDatastore) GetSize(key datastore.Key) (size int, err error) {
+	if v, found := d.values[key]; found {
+		return len(v), nil
+	}
+	return -1, datastore.ErrNotFound
+}
+
+// Delete implements Datastore.Delete
+func (d *MapDatastore) Delete(key datastore.Key) (err error) {
+	d.lk.Lock()
+	defer d.lk.Unlock()
+	delete(d.values, key)
+	return nil
+}
+
+// Query implements Datastore.Query
+func (d *MapDatastore) Query(q dsq.Query) (dsq.Results, error) {
+	d.lk.RLock()
+	defer d.lk.RUnlock()
+	re := make([]dsq.Entry, 0, len(d.values))
+	for k, v := range d.values {
+		e := dsq.Entry{Key: k.String(), Size: len(v)}
+		if !q.KeysOnly {
+			e.Value = v
+		}
+		re = append(re, e)
+	}
+	r := dsq.ResultsWithEntries(q, re)
+	r = dsq.NaiveQueryApply(q, r)
+	return r, nil
+}
+
+func (d *MapDatastore) Batch() (datastore.Batch, error) {
+	d.lk.Lock()
+	defer d.lk.Unlock()
+	return datastore.NewBasicBatch(d), nil
+}
+
+func (d *MapDatastore) Close() error {
+	return nil
+}

--- a/test/datastore/datastore_test.go
+++ b/test/datastore/datastore_test.go
@@ -1,0 +1,28 @@
+package datastore_test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	dstore "github.com/ipfs/go-datastore"
+	dstest "github.com/ipfs/go-datastore/test"
+)
+
+func TestMapDatastore(t *testing.T) {
+	ds := dstore.NewMapDatastore()
+	dstest.SubtestAll(t, ds)
+}
+
+func TestNullDatastore(t *testing.T) {
+	ds := dstore.NewNullDatastore()
+	// The only test that passes. Nothing should be found.
+	dstest.SubtestNotFounds(t, ds)
+}
+
+func TestLogDatastore(t *testing.T) {
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(ioutil.Discard)
+	ds := dstore.NewLogDatastore(dstore.NewMapDatastore(), "")
+	dstest.SubtestAll(t, ds)
+}

--- a/test/datastore/datastore_test.go
+++ b/test/datastore/datastore_test.go
@@ -1,28 +1,13 @@
 package datastore_test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
-	dstore "github.com/ipfs/go-datastore"
 	dstest "github.com/ipfs/go-datastore/test"
+	dstore "github.com/willscott/go-legs/test/datastore"
 )
 
 func TestMapDatastore(t *testing.T) {
 	ds := dstore.NewMapDatastore()
-	dstest.SubtestAll(t, ds)
-}
-
-func TestNullDatastore(t *testing.T) {
-	ds := dstore.NewNullDatastore()
-	// The only test that passes. Nothing should be found.
-	dstest.SubtestNotFounds(t, ds)
-}
-
-func TestLogDatastore(t *testing.T) {
-	defer log.SetOutput(log.Writer())
-	log.SetOutput(ioutil.Discard)
-	ds := dstore.NewLogDatastore(dstore.NewMapDatastore(), "")
 	dstest.SubtestAll(t, ds)
 }


### PR DESCRIPTION
This PR:
- Fixes the subscriber selector to `ExploreRecursiveWithStop` in order to be able to perform partial sync.
- Adds `latestSync` in subscribers so when there is a new update they don't need to sync the DAG from scratch if they've already seen some part of it.
- Adds a bunch of tests to see if everything works.