### PR TITLE
Do not delete the system TMPDIR

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -26,6 +26,9 @@ type legPublisher struct {
 }
 
 // NewPublisher creates a new legs publisher
+//
+// TODO: Add a parameter or config to set the directory that the publisher's
+// tmpDir is created in
 func NewPublisher(ctx context.Context, dataStore datastore.Batching, host host.Host, topic string, lsys ipld.LinkSystem) (LegPublisher, error) {
 
 	t, err := makePubsub(ctx, host, topic)

--- a/publish.go
+++ b/publish.go
@@ -2,6 +2,7 @@ package legs
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 
 	dt "github.com/filecoin-project/go-data-transfer"
@@ -37,7 +38,10 @@ func NewPublisher(ctx context.Context, dataStore datastore.Batching, host host.H
 	tp := gstransport.NewTransport(host.ID(), gs)
 	dtNet := dtnetwork.NewFromLibp2pHost(host)
 
-	tmpDir := os.TempDir()
+	tmpDir, err := ioutil.TempDir("", "golegs-pub")
+	if err != nil {
+		return nil, err
+	}
 
 	dt, err := datatransfer.NewDataTransfer(dataStore, tmpDir, dtNet, tp)
 	if err != nil {

--- a/subscribe.go
+++ b/subscribe.go
@@ -2,6 +2,7 @@ package legs
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"sync"
 
@@ -77,7 +78,10 @@ func newSubscriber(ctx context.Context, ds datastore.Batching, host host.Host, t
 	tp := gstransport.NewTransport(host.ID(), gs)
 	dtNet := dtnetwork.NewFromLibp2pHost(host)
 
-	tmpDir := os.TempDir()
+	tmpDir, err := ioutil.TempDir("", "golegs-sub")
+	if err != nil {
+		return nil, err
+	}
 
 	dt, err := datatransfer.NewDataTransfer(ds, tmpDir, dtNet, tp)
 	if err != nil {

--- a/subscribe.go
+++ b/subscribe.go
@@ -67,6 +67,8 @@ func NewSubscriberPartiallySynced(
 	return l, nil
 }
 
+// TODO: Add a parameter or config to set the directory that the subscriber's
+// tmpDir is created in
 func newSubscriber(ctx context.Context, ds datastore.Batching, host host.Host, topic string, lsys ipld.LinkSystem, policy PolicyHandler) (*legSubscriber, error) {
 	t, err := makePubsub(ctx, host, topic)
 	if err != nil {


### PR DESCRIPTION
This change makes publish and subscribe create their own temp dir and delete it on Close, instead of using the system temp dir and then trying to delete that (causing all of a user's files in that directory to get deleted).