### PR TITLE
Fix possible race on Close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,25 @@ func watch(notifications <-chan legs.SyncFinished) {
 
 To shutdown a `Subscriber`, call its `Close()` method.
 
-A `Subscriber` can be created with a `AllowPeer` function.  This function determines if the `Subscriber` accepts or rejects messages from a publisher, when a message is received from a new publisher with whom a sync has not already been done.
-
-The `Subscriber` keeps track of the latest head for each publisher that it has synced. This avoids exchanging the whole DAG from scratch in every update and instead downloads only the part that has not been synced. This value is not persisted as part of the library. If you want to start a `Subscriber` which has already partially synced with a provider you can use:
+A `Subscriber` can be created with a function that determines if the `Subscriber` accepts or rejects messages from a publisher.  Use the `AllowPeer` option to specify the function.
 ```golang
-sub, err := legs.NewSubscriber(dstHost, dstStore, dstLnkS, "/legs/topic", allowPeer)
+sub, err := legs.NewSubscriber(dstHost, dstStore, dstLnkS, "/legs/topic", nil, legs.AllowPeer(allowPeer))
+```
+
+The `Subscriber` keeps track of the latest head for each publisher that it has synced. This avoids exchanging the whole DAG from scratch in every update and instead downloads only the part that has not been synced. This value is not persisted as part of the library. If you want to start a `Subscriber` which has already partially synced with a provider you can use the `SetLatestSync` method:
+```golang
+sub, err := legs.NewSubscriber(dstHost, dstStore, dstLnkS, "/legs/topic", nil)
 if err != nil {
     panic(err)
 }
 // Set up partially synced publishers
-if err = brk.SetLatestSync(peerID1, lastSync1) ; err != nil {
+if err = sub.SetLatestSync(peerID1, lastSync1) ; err != nil {
     panic(err)
 }
-if err = brk.SetLatestSync(peerID2, lastSync2) ; err != nil {
+if err = sub.SetLatestSync(peerID2, lastSync2) ; err != nil {
     panic(err)
 }
-if err = brk.SetLatestSync(peerID3, lastSync3) ; err != nil {
+if err = sub.SetLatestSync(peerID3, lastSync3) ; err != nil {
     panic(err)
 }
 ```

--- a/dtsync/publisher.go
+++ b/dtsync/publisher.go
@@ -51,7 +51,7 @@ func NewPublisher(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, t
 		}
 	}
 
-	dtManager, _, dtClose, err := makeDataTransfer(host, ds, lsys, nil)
+	dtManager, _, dtClose, err := makeDataTransfer(host, ds, lsys)
 	if err != nil {
 		if cancel != nil {
 			cancel()

--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -72,7 +72,7 @@ func makeIncomingBlockHook(blockHook func(peer.ID, cid.Cid)) graphsync.OnIncomin
 	}
 }
 
-// Close ungeristers datatransfer event notification. If this Sync owns the
+// Close unregisters datatransfer event notification. If this Sync owns the
 // datatransfer.Manager then the Manager is stopped.
 func (s *Sync) Close() error {
 	s.unsubEvents()

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -10,17 +10,20 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+// Syncer handles a single sync with a provider.
 type Syncer struct {
 	peerID    peer.ID
 	sync      *Sync
 	topicName string
 }
 
+// GetHead queries a provider for the latest CID.
 func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
-	// Query the peer for the latest CID
 	return head.QueryRootCid(ctx, s.sync.host, s.topicName, s.peerID)
 }
 
+// Sync opens a datatransfer data channel and uses the selector to pull data
+// from the provider.
 func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error {
 	syncDone := s.sync.notifyOnSyncDone(nextCid)
 

--- a/dtsync/util.go
+++ b/dtsync/util.go
@@ -36,7 +36,7 @@ func configureDataTransferForLegs(ctx context.Context, dtManager dt.Manager, lsy
 		return err
 	}
 	if err := dtManager.RegisterTransportConfigurer(v, lsc.configureTransport); err != nil {
-		log.Errorf("Failed to register datatrasfer TransportConfigurer: %s", err)
+		log.Errorf("Failed to register datatransfer TransportConfigurer: %s", err)
 		return err
 	}
 	return nil
@@ -120,7 +120,7 @@ func makeDataTransfer(host host.Host, ds datastore.Batching, lsys ipld.LinkSyste
 		return nil, nil, nil, err
 	}
 
-	// Wait for datatrnasfer to be ready.
+	// Wait for datatransfer to be ready.
 	err = <-dtReady
 	if err != nil {
 		return nil, nil, nil, err

--- a/httpsync/sync.go
+++ b/httpsync/sync.go
@@ -177,7 +177,7 @@ func (s *Syncer) fetch(ctx context.Context, rsrc string, cb func(io.Reader) erro
 	return cb(resp.Body)
 }
 
-// fetchBlock fetches an item into the datastore at c if not locally avilable.
+// fetchBlock fetches an item into the datastore at c if not locally available.
 func (s *Syncer) fetchBlock(ctx context.Context, c cid.Cid) error {
 	n, err := s.sync.lsys.Load(ipld.LinkContext{}, cidlink.Link{Cid: c}, basicnode.Prototype.Any)
 	// node is already present.

--- a/interface.go
+++ b/interface.go
@@ -10,9 +10,9 @@ import (
 
 // Publisher is an interface for updating the published dag.
 type Publisher interface {
-	// Publishes and update for the DAG in the pubsub channel.
+	// Publishes an update for the DAG in the pubsub channel.
 	UpdateRoot(context.Context, cid.Cid) error
-	// Publishes and update for the DAG in the pubsub channel using custom multiaddrs.
+	// Publishes an update for the DAG in the pubsub channel using custom multiaddrs.
 	UpdateRootWithAddrs(context.Context, cid.Cid, []ma.Multiaddr) error
 	// Close publisher
 	Close() error

--- a/legs_test.go
+++ b/legs_test.go
@@ -146,7 +146,11 @@ func TestRoundTripExistingDataTransfer(t *testing.T) {
 		return true, nil
 	}
 
-	sub, err := legs.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, legs.Topic(topics[1]), legs.DtManager(dtManagerDst), legs.AllowPeer(allowAll), legs.HttpClient(http.DefaultClient), legs.AddrTTL(time.Hour))
+	blockHook := func(p peer.ID, c cid.Cid) {
+		t.Fatal("blockHook should not be called with passed-in datatransfer manager")
+	}
+
+	sub, err := legs.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, legs.Topic(topics[1]), legs.DtManager(dtManagerDst), legs.AllowPeer(allowAll), legs.HttpClient(http.DefaultClient), legs.AddrTTL(time.Hour), legs.BlockHook(blockHook))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/subscriber.go
+++ b/subscriber.go
@@ -318,7 +318,7 @@ func (s *Subscriber) OnSyncFinished() (<-chan SyncFinished, context.CancelFunc) 
 // after the latest sync in order to avid re-syncing of content that may have
 // previously been synced.
 //
-// The selector sequence, selSec, can optionally be specified to customize the
+// The selector sequence, sel, can optionally be specified to customize the
 // selection sequence during traversal.  If unspecified, the default selector
 // sequence is used.
 //


### PR DESCRIPTION
When closing the `Subscriber` it is possible that an advertisement is being still handled, and datatransfer gets used after being closed.  This waits for any async handler goroutines to exit and the pubsub watcher to exit before closing datatransfer. 
