### PR TITLE
No op if we are already synced

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -583,13 +583,17 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, ss ipld.Node
 // is locked.
 func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel, updateLatest bool, syncer Syncer) error {
 	if wrapSel {
-		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
-
+		// Note this branch is nested under wrapSel because wrapSel adds the
+		// semantics that we stop when we hit the `h.latestSync` node. This is a
+		// special case where we are starting at the stop node so we can just
+		// return.
 		if h.latestSync != nil && h.latestSync.(cidlink.Link).Cid == nextCid {
 			// Nothing to do. We've already synced to this cid because we have it as h.latestSync.
 			log.Debugw("Already synced.", "cid", nextCid, "peer", h.peerID)
 			return nil
 		}
+
+		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
 	}
 
 	err := syncer.Sync(ctx, nextCid, sel)

--- a/subscriber.go
+++ b/subscriber.go
@@ -584,6 +584,12 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, ss ipld.Node
 func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel, updateLatest bool, syncer Syncer) error {
 	if wrapSel {
 		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
+
+		if h.latestSync != nil && h.latestSync.(cidlink.Link).Cid == nextCid {
+			// Nothing to do. We've already synced to this cid because we have it as h.latestSync.
+			log.Debugw("Already synced.", "cid", nextCid, "peer", h.peerID)
+			return nil
+		}
 	}
 
 	err := syncer.Sync(ctx, nextCid, sel)

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -39,6 +39,11 @@ func TestSync(t *testing.T) {
 			}
 
 			head := ll.Build(t, lsys)
+			if head == nil {
+				// We built an empty list. So nothing to test.
+				return
+			}
+
 			err = pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
 			if err != nil {
 				t.Fatal(err)

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -2,7 +2,9 @@ package legs_test
 
 import (
 	"context"
+	"math/rand"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/filecoin-project/go-legs"
@@ -11,15 +13,76 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/linking"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multicodec"
 )
 
 const (
 	testTopic     = "/legs/testtopic"
 	updateTimeout = 1 * time.Second
 )
+
+func TestSync(t *testing.T) {
+	err := quick.Check(func(ll llBuilder) bool {
+		return t.Run("Quickcheck", func(t *testing.T) {
+			ds := dssync.MutexWrap(datastore.NewMapDatastore())
+			pubHost := test.MkTestHost()
+			lsys := test.MkLinkSystem(ds)
+			pub, err := dtsync.NewPublisher(pubHost, ds, lsys, testTopic)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			head := ll.Build(t, lsys)
+			err = pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			subDS := dssync.MutexWrap(datastore.NewMapDatastore())
+			subLsys := test.MkLinkSystem(ds)
+			subHost := test.MkTestHost()
+
+			calledTimes := 0
+			sub, err := legs.NewSubscriber(subHost, subDS, subLsys, testTopic, nil, legs.BlockHook(func(i peer.ID, c cid.Cid) {
+				calledTimes++
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Now sync again. We shouldn't call the hook.
+			_, err = sub.Sync(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			calledTimesFirstSync := calledTimes
+			latestSync := sub.GetLatestSync(pubHost.ID())
+			if latestSync != head {
+				t.Fatalf("Subscriber did not persist latest sync")
+			}
+			_, err = sub.Sync(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calledTimesFirstSync != calledTimes {
+				t.Fatalf("Subscriber called the block hook multiple times for the same sync. Expected %d, got %d", calledTimesFirstSync, calledTimes)
+			}
+
+		})
+	}, &quick.Config{
+		MaxCount: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
 
 func TestRoundTripSimple(t *testing.T) {
 	// Init legs publisher and subscriber
@@ -203,4 +266,67 @@ func TestCloseSubscriber(t *testing.T) {
 	case <-time.After(updateTimeout):
 		t.Fatal("OnSyncFinished cancel func did not return after Close")
 	}
+}
+
+type llBuilder struct {
+	Length uint8
+	Seed   int64
+}
+
+func (b llBuilder) Build(t *testing.T, lsys ipld.LinkSystem) datamodel.Link {
+	var linkproto = cidlink.LinkPrototype{
+		Prefix: cid.Prefix{
+			Version:  1,
+			Codec:    uint64(multicodec.DagJson),
+			MhType:   uint64(multicodec.Sha2_256),
+			MhLength: 16,
+		},
+	}
+
+	rng := rand.New(rand.NewSource(b.Seed))
+	var prev datamodel.Link
+	for i := 0; i < int(b.Length); i++ {
+		p := basicnode.Prototype.Map
+		b := p.NewBuilder()
+		ma, err := b.BeginMap(2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		eb, err := ma.AssembleEntry("Value")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = eb.AssignInt(int64(rng.Intn(100)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		eb, err = ma.AssembleEntry("Next")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if prev != nil {
+			err = eb.AssignLink(prev)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			err = eb.AssignNull()
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		err = ma.Finish()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		n := b.Build()
+
+		prev, err = lsys.Store(linking.LinkContext{}, linkproto, n)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return prev
 }


### PR DESCRIPTION
## Context

There's a surprising behavior where if you call subscriber.Sync twice with no selector and cid.Undef you will traverse the whole chain instead of stopping on the latestSync.

For example:
Assume publisher `P` has a linked list of blocks:
A <- B <- C.

When we call
```
sub.Sync(ctx, pID, cid.Undef, nil, pAddr)
```
We set `h.latestSync == C`. And we call our block hook fn for `C, B, A`.

If we then call 
```
sub.Sync(ctx, pID, cid.Undef, nil, pAddr) // or C instead of cid.Undef
```
We should expect this to be a no-op since we are already synced. However what actually happens is that we call our block hook fn for `C, B, A` again.

This causes some subtle bugs on the indexer that doesn't expect this behavior (specifically it expects that once a block has been ingested it won't try to be ingested again. Although indexer has some gaurd rails to prevent inconsistency here).

## Proposed Solution
Check if `h.latestSync == cidToSyncTo` in the handler.handle func since we should already have a lock here.

Added a new test that builds a random linked list and tests this behavior.