### PR TITLE
Fix dead handler when two handlers sync the same cid

### DIFF
--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -25,14 +25,14 @@ func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
 // Sync opens a datatransfer data channel and uses the selector to pull data
 // from the provider.
 func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error {
-	syncDone := s.sync.notifyOnSyncDone(nextCid)
+	syncDone := s.sync.notifyOnSyncDone(inProgressSyncKey{nextCid, s.peerID})
 
 	log.Debugw("Starting data channel for message source", "cid", nextCid, "source_peer", s.peerID)
 
 	v := Voucher{&nextCid}
 	_, err := s.sync.dtManager.OpenPullDataChannel(ctx, s.peerID, &v, nextCid, sel)
 	if err != nil {
-		s.sync.signalSyncDone(nextCid, nil)
+		s.sync.signalSyncDone(inProgressSyncKey{nextCid, s.peerID}, nil)
 		return fmt.Errorf("cannot open data channel: %s", err)
 	}
 

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -105,7 +105,7 @@ func TestConcurrentSync(t *testing.T) {
 			}()
 
 			select {
-			case <-time.After(5 * time.Second):
+			case <-time.After(10 * time.Second):
 				t.Fatal("Failed to sync")
 			case <-doneChan:
 			}


### PR DESCRIPTION
## Context

Since we are only tracking in-progress syncs with a cid if two handlers start syncing the same cid (from two different providers) one will fail and stall indefinitely.

## Proposed Solution

This adds the peer we are syncing from as part of the key for tracking in progress syncs so handlers can't clobber each other (since there is one handler per peer).