### PR TITLE
Send error if syncer is closed

### DIFF
--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -96,6 +96,7 @@ func (s *Sync) Close() error {
 		log.Warnf("Closing datatransfer sync with %d syncs in progress", len(s.syncDoneChans))
 	}
 	for _, ch := range s.syncDoneChans {
+		ch <- errors.New("sync closed")
 		close(ch)
 	}
 	s.syncDoneChans = nil


### PR DESCRIPTION
## Context

If we were closed a subscriber while syncing callers would believe that the sync completed successfully since no error returned. There was no way for a caller to know the sync failed (which it did because the whole thing shutdown)

For example if we're syncing chain A<-B<-C, and we shutdown the subscriber after syncing A but before finishing B, the caller would think that the whole chain was synced successfully.

## Proposed solution

Propagate an error that the sync was closed.