### PR TITLE
HTTP Peerstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/libp2p/go-libp2p v0.18.0-rc1
 	github.com/libp2p/go-libp2p-core v0.14.0
 	github.com/libp2p/go-libp2p-gostream v0.3.1
+	github.com/libp2p/go-libp2p-peerstore v0.6.0
 	github.com/libp2p/go-libp2p-pubsub v0.6.1
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multicodec v0.4.0

--- a/subscriber.go
+++ b/subscriber.go
@@ -367,9 +367,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 				break
 			}
 		}
-	}
-
-	if peerAddr == nil {
+	} else {
 		// Check if we have an http url for this peer since we didn't get a peerAddr.
 		// Note that this gives a preference to use httpSync over dtsync if we have
 		// seen http address and we called sync with no explicit peerAddr.

--- a/subscriber.go
+++ b/subscriber.go
@@ -374,7 +374,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 	}
 
 	if peerAddr == nil {
-		// Check if we have an http url for this peer since we didn't get an peerAddr.
+		// Check if we have an http url for this peer since we didn't get a peerAddr.
 		// Note that this gives a preference to use httpSync over dtsync if we have
 		// seen http address and we called sync with no explicit peerAddr.
 		possibleAddrs := s.httpPeerstore.Addrs(peerID)

--- a/subscriber.go
+++ b/subscriber.go
@@ -382,6 +382,15 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 			return cid.Undef, fmt.Errorf("cannot create http sync handler: %w", err)
 		}
 	} else {
+		// Not an httpPeerAddr, so use the dtSync. We'll add it with a small TTL
+		// first, and extend it when we discover we can actually sync from it.
+		// In case the peerstore already has this address and the existing TTL is
+		// greater than this temp one, this is a no-op. In other words we never
+		// decrease the TTL here.
+		peerStore := s.host.Peerstore()
+		if peerStore != nil {
+			peerStore.AddAddr(peerID, peerAddr, peerstore.TempAddrTTL)
+		}
 		syncer = s.dtSync.NewSyncer(peerID, s.topicName)
 	}
 

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -131,22 +131,8 @@ func TestConcurrentSync(t *testing.T) {
 func TestSync(t *testing.T) {
 	err := quick.Check(func(lpsb legsPubSubBuilder, ll llBuilder) bool {
 		return t.Run("Quickcheck", func(t *testing.T) {
-			pubPrivKey, _, err := crypto.GenerateEd25519Key(cryptorand.Reader)
-			require.NoError(t, err)
-
-			pubDs := dssync.MutexWrap(datastore.NewMapDatastore())
-			pubSys := hostSystem{
-				privKey: pubPrivKey,
-				host:    test.MkTestHost(libp2p.Identity(pubPrivKey)),
-				ds:      pubDs,
-				lsys:    test.MkLinkSystem(pubDs),
-			}
-			subDs := dssync.MutexWrap(datastore.NewMapDatastore())
-			subSys := hostSystem{
-				host: test.MkTestHost(),
-				ds:   subDs,
-				lsys: test.MkLinkSystem(subDs),
-			}
+			pubSys := newHostSystem(t)
+			subSys := newHostSystem(t)
 
 			calledTimes := 0
 			pubAddr, pub, sub := lpsb.Build(t, testTopic, pubSys, subSys,
@@ -161,7 +147,7 @@ func TestSync(t *testing.T) {
 				return
 			}
 
-			err = pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
+			err := pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -384,6 +384,52 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestHttpPeerAddrPeerstore(t *testing.T) {
+	pubHostSys := newHostSystem(t)
+	subHostSys := newHostSystem(t)
+
+	pubAddr, pub, sub := legsPubSubBuilder{
+		IsHttp: true,
+	}.Build(t, testTopic, pubHostSys, subHostSys, nil)
+
+	ll := llBuilder{
+		Length: 3,
+		Seed:   1,
+	}.Build(t, pubHostSys.lsys)
+
+	// a new link on top of ll
+	nextLL := llBuilder{
+		Length: 1,
+		Seed:   2,
+	}.BuildWithPrev(t, pubHostSys.lsys, ll)
+
+	prevHead := ll
+	head := nextLL
+
+	err := pub.UpdateRoot(context.Background(), prevHead.(cidlink.Link).Cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = sub.Sync(context.Background(), pubHostSys.host.ID(), cid.Undef, nil, pubAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now call sync again with no address. The subscriber should re-use the
+	// previous address and succeeed.
+	_, err = sub.Sync(context.Background(), pubHostSys.host.ID(), cid.Undef, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
 func waitForSync(t *testing.T, logPrefix string, store *dssync.MutexDatastore, expectedCid cidlink.Link, watcher <-chan legs.SyncFinished) {
 	select {
 	case <-time.After(updateTimeout):
@@ -455,6 +501,18 @@ type hostSystem struct {
 	lsys    ipld.LinkSystem
 }
 
+func newHostSystem(t *testing.T) hostSystem {
+	privKey, _, err := crypto.GenerateEd25519Key(cryptorand.Reader)
+	require.NoError(t, err)
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	return hostSystem{
+		privKey: privKey,
+		host:    test.MkTestHost(libp2p.Identity(privKey)),
+		ds:      ds,
+		lsys:    test.MkLinkSystem(ds),
+	}
+}
+
 func (b legsPubSubBuilder) Build(t *testing.T, topicName string, pubSys hostSystem, subSys hostSystem, subOpts []legs.Option) (multiaddr.Multiaddr, legs.Publisher, *legs.Subscriber) {
 	var pubAddr multiaddr.Multiaddr
 	var pub legs.Publisher
@@ -491,6 +549,10 @@ type llBuilder struct {
 }
 
 func (b llBuilder) Build(t *testing.T, lsys ipld.LinkSystem) datamodel.Link {
+	return b.BuildWithPrev(t, lsys, nil)
+}
+
+func (b llBuilder) BuildWithPrev(t *testing.T, lsys ipld.LinkSystem, prev datamodel.Link) datamodel.Link {
 	var linkproto = cidlink.LinkPrototype{
 		Prefix: cid.Prefix{
 			Version:  1,
@@ -501,7 +563,6 @@ func (b llBuilder) Build(t *testing.T, lsys ipld.LinkSystem) datamodel.Link {
 	}
 
 	rng := rand.New(rand.NewSource(b.Seed))
-	var prev datamodel.Link
 	for i := 0; i < int(b.Length); i++ {
 		p := basicnode.Prototype.Map
 		b := p.NewBuilder()


### PR DESCRIPTION
## Context

If a user called `.Sync` on on a peer with a nil address we would always try to use graphsync on it. This is a problem if the peer is really an http provider so it's not reachable via graphsync.

Internally graphsync would check the libp2p host's peerstore to get a recently used address for that peer.

## Proposed solution

Create a new http only peerstore, and remember peers' http address when we first get them.

* Why not re-use the libp2p host's peerstore?
  * We have no guarantee what other users of the host will do with this address. They may use it as an endpoint to connect to via libp2p, and that will fail.
  * The peerstore will broadcast address changes. We don't really want this for the same reason as above.
  * An http-only user shouldn't have to create a libp2p host just to get this functionality.
  
Currently no error handling and culling of the addresses (besides TTL) happens. 
 
## Semantics

* If a nil peerAddr is passed in and that peer has both an http and libp2p endpoint, the implementation will prefer the http endpoint.