### PR TITLE
Cleanup resources to shutdown goroutines

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -285,6 +285,9 @@ func (s *Subscriber) doClose() error {
 
 	// Stop the distribution goroutine.
 	close(s.inEvents)
+
+	s.httpPeerstore.Close()
+
 	return errs
 }
 


### PR DESCRIPTION
Need to shutdown http peerstore and graphsync.  Otherwise, they will leak goroutines.