### PR TITLE
SyncFinished Event now includes CIDs traversed

### DIFF
--- a/option.go
+++ b/option.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	dt "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
@@ -15,8 +14,9 @@ type config struct {
 	addrTTL   time.Duration
 	allowPeer AllowPeerFunc
 
-	topic      *pubsub.Topic
-	dtManager  dt.Manager
+	topic *pubsub.Topic
+	// TODO We can re-enable this when we figure out how to register a block hook with an existing dtManager
+	// dtManager  dt.Manager
 	blockHook  BlockHookFunc
 	httpClient *http.Client
 
@@ -57,14 +57,6 @@ func AddrTTL(addrTTL time.Duration) Option {
 func Topic(topic *pubsub.Topic) Option {
 	return func(c *config) error {
 		c.topic = topic
-		return nil
-	}
-}
-
-// DtManager provides an existing datatransfer manager.
-func DtManager(dtManager dt.Manager) Option {
-	return func(c *config) error {
-		c.dtManager = dtManager
 		return nil
 	}
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -186,17 +186,7 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 	scopedBlockHookMutex, scopedBlockHook, blockHook := wrapBlockHook(cfg.blockHook)
 
 	var dtSync *dtsync.Sync
-	if cfg.dtManager != nil {
-		if ds != nil {
-			log.Warn("Datastore cannot be used with DtManager option")
-		}
-		if cfg.blockHook != nil {
-			log.Warn("BlockHook option cannot be used with DtManager option")
-		}
-		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager)
-	} else {
-		dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
-	}
+	dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
 	if err != nil {
 		cancelPubsub()
 		return nil, err

--- a/subscriber.go
+++ b/subscriber.go
@@ -109,12 +109,10 @@ type Subscriber struct {
 // completed a sync.  The channel receives events from providers that are
 // manually synced to the latest, as well as those auto-discovered.
 type SyncFinished struct {
-	// Cid is the CID identifying the link that finished and is now the latest
-	// sync for a specific peer.
-	Cid cid.Cid
 	// PeerID identifies the peer this SyncFinished event pertains to.
 	PeerID peer.ID
-	// A list of cids that this sync acquired. In order from latest to oldest. The latest cid will always be at the beginning.
+	// A list of cids that this sync acquired. In order from latest to oldest. The
+	// latest cid will always be at the beginning
 	SyncedCids []cid.Cid
 }
 
@@ -515,7 +513,7 @@ func (s *Subscriber) SyncWithHook(ctx context.Context, peerID peer.ID, nextCid c
 // to all OnSyncFinished channel readers.
 func (s *Subscriber) distributeEvents() {
 	for event := range s.inEvents {
-		if !event.Cid.Defined() {
+		if len(event.SyncedCids) == 0 {
 			panic("SyncFinished event with undefined cid")
 		}
 		// Send update to all change notification channels.
@@ -718,7 +716,7 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 
 	// Tell the Subscriber to distribute SyncFinished to all notification
 	// destinations.
-	h.subscriber.inEvents <- SyncFinished{Cid: nextCid, PeerID: h.peerID, SyncedCids: syncedCids}
+	h.subscriber.inEvents <- SyncFinished{PeerID: h.peerID, SyncedCids: syncedCids}
 
 	return nil
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -75,6 +75,11 @@ type Subscriber struct {
 	handlers      map[peer.ID]*handler
 	handlersMutex sync.Mutex
 
+	// A map of block hooks to call for a specific peer id, instead of the general
+	// block hook func.
+	scopedBlockHook      map[peer.ID]BlockHookFunc
+	scopedBlockHookMutex *sync.RWMutex
+
 	// inEvents is used to send a SyncFinished from a peer handler to the
 	// distributeEvents goroutine.
 	inEvents chan SyncFinished
@@ -122,6 +127,23 @@ type handler struct {
 	syncMutex sync.Mutex
 }
 
+// wrapBlockHook wraps a possibly nil block hook func to allow a for dispatching
+// to a blockhook func that is scoped within a .Sync call.
+func wrapBlockHook(generalBlockHook BlockHookFunc) (*sync.RWMutex, map[peer.ID]BlockHookFunc, BlockHookFunc) {
+	var scopedBlockHookMutex sync.RWMutex
+	scopedBlockHook := make(map[peer.ID]BlockHookFunc)
+	return &scopedBlockHookMutex, scopedBlockHook, func(peerID peer.ID, cid cid.Cid) {
+		scopedBlockHookMutex.RLock()
+		f, ok := scopedBlockHook[peerID]
+		scopedBlockHookMutex.RUnlock()
+		if ok {
+			f(peerID, cid)
+		} else if generalBlockHook != nil {
+			generalBlockHook(peerID, cid)
+		}
+	}
+}
+
 // NewSubscriber creates a new Subscriber that process pubsub messages.
 func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, topic string, dss ipld.Node, options ...Option) (*Subscriber, error) {
 	cfg := config{
@@ -149,6 +171,8 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 		return nil, err
 	}
 
+	scopedBlockHookMutex, scopedBlockHook, blockHook := wrapBlockHook(cfg.blockHook)
+
 	var dtSync *dtsync.Sync
 	if cfg.dtManager != nil {
 		if ds != nil {
@@ -159,7 +183,7 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 		}
 		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager)
 	} else {
-		dtSync, err = dtsync.NewSync(host, ds, lsys, cfg.blockHook)
+		dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
 	}
 	if err != nil {
 		cancelPubsub()
@@ -189,10 +213,13 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 		inEvents:  make(chan SyncFinished, 1),
 
 		dtSync:       dtSync,
-		httpSync:     httpsync.NewSync(lsys, cfg.httpClient, cfg.blockHook),
+		httpSync:     httpsync.NewSync(lsys, cfg.httpClient, blockHook),
 		syncRecLimit: cfg.syncRecLimit,
 
 		httpPeerstore: httpPeerstore,
+
+		scopedBlockHookMutex: scopedBlockHookMutex,
+		scopedBlockHook:      scopedBlockHook,
 	}
 
 	// Start watcher to read pubsub messages.
@@ -351,6 +378,10 @@ func (s *Subscriber) OnSyncFinished() (<-chan SyncFinished, context.CancelFunc) 
 //
 // See: ExploreRecursiveWithStopNode.
 func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, sel ipld.Node, peerAddr multiaddr.Multiaddr) (cid.Cid, error) {
+	return s.SyncWithHook(ctx, peerID, nextCid, sel, peerAddr, nil)
+}
+
+func (s *Subscriber) SyncWithHook(ctx context.Context, peerID peer.ID, nextCid cid.Cid, sel ipld.Node, peerAddr multiaddr.Multiaddr, hook BlockHookFunc) (cid.Cid, error) {
 	if peerID == "" {
 		return cid.Undef, errors.New("empty peer id")
 	}
@@ -443,6 +474,20 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 
 	hnd.syncMutex.Lock()
 	defer hnd.syncMutex.Unlock()
+
+	if hook != nil {
+		s.scopedBlockHookMutex.Lock()
+		s.scopedBlockHook[peerID] = hook
+		s.scopedBlockHookMutex.Unlock()
+		defer func() {
+			s.scopedBlockHookMutex.Lock()
+			if s.scopedBlockHook == nil {
+				s.scopedBlockHook = make(map[peer.ID]BlockHookFunc)
+			}
+			delete(s.scopedBlockHook, peerID)
+			s.scopedBlockHookMutex.Unlock()
+		}()
+	}
 
 	err = hnd.handle(ctx, nextCid, sel, wrapSel, updateLatest, syncer)
 	if err != nil {

--- a/subscriber.go
+++ b/subscriber.go
@@ -109,10 +109,12 @@ type Subscriber struct {
 // completed a sync.  The channel receives events from providers that are
 // manually synced to the latest, as well as those auto-discovered.
 type SyncFinished struct {
+	// Cid is the CID identifying the link that finished and is now the latest
+	// sync for a specific peer.
+	Cid cid.Cid
 	// PeerID identifies the peer this SyncFinished event pertains to.
 	PeerID peer.ID
-	// A list of cids that this sync acquired. In order from latest to oldest. The
-	// latest cid will always be at the beginning
+	// A list of cids that this sync acquired. In order from latest to oldest. The latest cid will always be at the beginning.
 	SyncedCids []cid.Cid
 }
 
@@ -513,7 +515,7 @@ func (s *Subscriber) SyncWithHook(ctx context.Context, peerID peer.ID, nextCid c
 // to all OnSyncFinished channel readers.
 func (s *Subscriber) distributeEvents() {
 	for event := range s.inEvents {
-		if len(event.SyncedCids) == 0 {
+		if !event.Cid.Defined() {
 			panic("SyncFinished event with undefined cid")
 		}
 		// Send update to all change notification channels.
@@ -716,7 +718,7 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 
 	// Tell the Subscriber to distribute SyncFinished to all notification
 	// destinations.
-	h.subscriber.inEvents <- SyncFinished{PeerID: h.peerID, SyncedCids: syncedCids}
+	h.subscriber.inEvents <- SyncFinished{Cid: nextCid, PeerID: h.peerID, SyncedCids: syncedCids}
 
 	return nil
 }

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -403,10 +403,10 @@ func TestRoundTripSimple(t *testing.T) {
 	case <-time.After(updateTimeout):
 		t.Fatal("timed out waiting for sync to propogate")
 	case downstream := <-watcher:
-		if !downstream.SyncedCids[0].Equals(lnk.(cidlink.Link).Cid) {
-			t.Fatalf("sync'd cid unexpected %s vs %s", downstream.SyncedCids[0], lnk)
+		if !downstream.Cid.Equals(lnk.(cidlink.Link).Cid) {
+			t.Fatalf("sync'd cid unexpected %s vs %s", downstream.Cid, lnk)
 		}
-		if _, err := dstStore.Get(context.Background(), datastore.NewKey(downstream.SyncedCids[0].String())); err != nil {
+		if _, err := dstStore.Get(context.Background(), datastore.NewKey(downstream.Cid.String())); err != nil {
 			t.Fatalf("data not in receiver store: %v", err)
 		}
 	}
@@ -549,13 +549,13 @@ func waitForSync(t *testing.T, logPrefix string, store *dssync.MutexDatastore, e
 	case <-time.After(updateTimeout):
 		t.Fatal("timed out waiting for sync to propogate")
 	case downstream := <-watcher:
-		if !downstream.SyncedCids[0].Equals(expectedCid.Cid) {
+		if !downstream.Cid.Equals(expectedCid.Cid) {
 			t.Fatalf("sync'd cid unexpected %s vs %s", downstream, expectedCid.Cid)
 		}
-		if _, err := store.Get(context.Background(), datastore.NewKey(downstream.SyncedCids[0].String())); err != nil {
+		if _, err := store.Get(context.Background(), datastore.NewKey(downstream.Cid.String())); err != nil {
 			t.Fatalf("data not in receiver store: %v", err)
 		}
-		t.Log(logPrefix+" got sync:", downstream.SyncedCids[0])
+		t.Log(logPrefix+" got sync:", downstream.Cid)
 	}
 
 }

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -403,10 +403,10 @@ func TestRoundTripSimple(t *testing.T) {
 	case <-time.After(updateTimeout):
 		t.Fatal("timed out waiting for sync to propogate")
 	case downstream := <-watcher:
-		if !downstream.Cid.Equals(lnk.(cidlink.Link).Cid) {
-			t.Fatalf("sync'd cid unexpected %s vs %s", downstream.Cid, lnk)
+		if !downstream.SyncedCids[0].Equals(lnk.(cidlink.Link).Cid) {
+			t.Fatalf("sync'd cid unexpected %s vs %s", downstream.SyncedCids[0], lnk)
 		}
-		if _, err := dstStore.Get(context.Background(), datastore.NewKey(downstream.Cid.String())); err != nil {
+		if _, err := dstStore.Get(context.Background(), datastore.NewKey(downstream.SyncedCids[0].String())); err != nil {
 			t.Fatalf("data not in receiver store: %v", err)
 		}
 	}
@@ -549,13 +549,13 @@ func waitForSync(t *testing.T, logPrefix string, store *dssync.MutexDatastore, e
 	case <-time.After(updateTimeout):
 		t.Fatal("timed out waiting for sync to propogate")
 	case downstream := <-watcher:
-		if !downstream.Cid.Equals(expectedCid.Cid) {
+		if !downstream.SyncedCids[0].Equals(expectedCid.Cid) {
 			t.Fatalf("sync'd cid unexpected %s vs %s", downstream, expectedCid.Cid)
 		}
-		if _, err := store.Get(context.Background(), datastore.NewKey(downstream.Cid.String())); err != nil {
+		if _, err := store.Get(context.Background(), datastore.NewKey(downstream.SyncedCids[0].String())); err != nil {
 			t.Fatalf("data not in receiver store: %v", err)
 		}
-		t.Log(logPrefix+" got sync:", downstream.Cid)
+		t.Log(logPrefix+" got sync:", downstream.SyncedCids[0])
 	}
 
 }

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -41,6 +41,79 @@ type pubMeta struct {
 	h   host.Host
 }
 
+func TestScopedBlockHook(t *testing.T) {
+	err := quick.Check(func(ll llBuilder) bool {
+		return t.Run("Quickcheck", func(t *testing.T) {
+			ds := dssync.MutexWrap(datastore.NewMapDatastore())
+			pubHost := test.MkTestHost()
+			lsys := test.MkLinkSystem(ds)
+			pub, err := dtsync.NewPublisher(pubHost, ds, lsys, testTopic)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			head := ll.Build(t, lsys)
+			if head == nil {
+				// We built an empty list. So nothing to test.
+				return
+			}
+
+			err = pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			subDS := dssync.MutexWrap(datastore.NewMapDatastore())
+			subLsys := test.MkLinkSystem(subDS)
+			subHost := test.MkTestHost()
+
+			var calledGeneralBlockHookTimes int64
+			sub, err := legs.NewSubscriber(subHost, subDS, subLsys, testTopic, nil, legs.BlockHook(func(i peer.ID, c cid.Cid) {
+				atomic.AddInt64(&calledGeneralBlockHookTimes, 1)
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var calledScopedBlockHookTimes int64
+			_, err = sub.SyncWithHook(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0], func(i peer.ID, c cid.Cid) {
+				atomic.AddInt64(&calledScopedBlockHookTimes, 1)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if atomic.LoadInt64(&calledGeneralBlockHookTimes) != int64(0) {
+				t.Fatalf("Shouldn't have called general block hook. Called %d times", atomic.LoadInt64(&calledGeneralBlockHookTimes))
+			}
+			if atomic.LoadInt64(&calledScopedBlockHookTimes) != int64(ll.Length) {
+				t.Fatalf("Didn't call scoped block hook enough times")
+			}
+
+			anotherLL := llBuilder{
+				Length: ll.Length,
+				Seed:   ll.Seed + 1,
+			}.Build(t, lsys)
+
+			pub.UpdateRoot(context.Background(), anotherLL.(cidlink.Link).Cid)
+			_, err = sub.Sync(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if atomic.LoadInt64(&calledGeneralBlockHookTimes) != int64(ll.Length) {
+				t.Fatalf("Didn't call general block hook enough times")
+			}
+
+		})
+	}, &quick.Config{
+		MaxCount: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestConcurrentSync(t *testing.T) {
 	err := quick.Check(func(ll llBuilder, publisherCount uint8) bool {
 		return t.Run("Quickcheck", func(t *testing.T) {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.2"
+  "version": "v0.3.3"
 }


### PR DESCRIPTION
We keep track of the cids traversed during a sync so that the syncfinished event has that information. This would remove the hack around cidwaiter and maybe simplify the implementation of the ingester proposal.
