### PR TITLE
Allow head query over libp2p using dns address

### DIFF
--- a/p2p/protocol/head/head.go
+++ b/p2p/protocol/head/head.go
@@ -62,11 +62,7 @@ func QueryRootCid(ctx context.Context, host host.Host, topic string, peerID peer
 				if err != nil {
 					return nil, err
 				}
-				conn, err := gostream.Dial(ctx, host, peerID, deriveProtocolID(topic))
-				if err != nil {
-					return nil, err
-				}
-				return conn, nil
+				return gostream.Dial(ctx, host, peerID, deriveProtocolID(topic))
 			},
 		},
 	}

--- a/p2p/protocol/head/head.go
+++ b/p2p/protocol/head/head.go
@@ -51,11 +51,22 @@ func (p *Publisher) Serve(host host.Host, topic string) error {
 	return p.server.Serve(l)
 }
 
-func QueryRootCid(ctx context.Context, host host.Host, topic string, peer peer.ID) (cid.Cid, error) {
+func QueryRootCid(ctx context.Context, host host.Host, topic string, peerID peer.ID) (cid.Cid, error) {
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return gostream.Dial(ctx, host, peer, deriveProtocolID(topic))
+				addrInfo := peer.AddrInfo{
+					ID: peerID,
+				}
+				err := host.Connect(ctx, addrInfo)
+				if err != nil {
+					return nil, err
+				}
+				conn, err := gostream.Dial(ctx, host, peerID, deriveProtocolID(topic))
+				if err != nil {
+					return nil, err
+				}
+				return conn, nil
 			},
 		},
 	}


### PR DESCRIPTION
Need to use `host.Connect` to  resolve DNS multiaddresses.

Fixes https://github.com/filecoin-project/storetheindex/issues/221