### PR TITLE
Re-enable DtManager subscriber option

### DIFF
--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -39,11 +39,15 @@ type Sync struct {
 
 // NewSyncWithDT creates a new Sync with a datatransfer.Manager provided by the
 // caller.
-func NewSyncWithDT(host host.Host, dtManager dt.Manager) (*Sync, error) {
+func NewSyncWithDT(host host.Host, dtManager dt.Manager, gs graphsync.GraphExchange, blockHook func(peer.ID, cid.Cid)) (*Sync, error) {
 	registerVoucher(dtManager)
 	s := &Sync{
 		host:      host,
 		dtManager: dtManager,
+	}
+
+	if blockHook != nil {
+		s.unregHook = gs.RegisterIncomingBlockHook(makeIncomingBlockHook(blockHook))
 	}
 
 	s.unsubEvents = dtManager.SubscribeToEvents(s.onEvent)

--- a/option.go
+++ b/option.go
@@ -11,10 +11,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
-type blockHookRegister interface {
-	RegisterIncomingBlockHook(graphsync.OnIncomingBlockHook) graphsync.UnregisterHookFunc
-}
-
 // config contains all options for configuring Subscriber.
 type config struct {
 	addrTTL   time.Duration

--- a/option.go
+++ b/option.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	dt "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
@@ -15,8 +16,8 @@ type config struct {
 	allowPeer AllowPeerFunc
 
 	topic *pubsub.Topic
-	// TODO We can re-enable this when we figure out how to register a block hook with an existing dtManager
-	// dtManager  dt.Manager
+	// TODO figure out how to register a block hook with an existing dtManager
+	dtManager  dt.Manager
 	blockHook  BlockHookFunc
 	httpClient *http.Client
 
@@ -57,6 +58,14 @@ func AddrTTL(addrTTL time.Duration) Option {
 func Topic(topic *pubsub.Topic) Option {
 	return func(c *config) error {
 		c.topic = topic
+		return nil
+	}
+}
+
+// DtManager provides an existing datatransfer manager.
+func DtManager(dtManager dt.Manager) Option {
+	return func(c *config) error {
+		c.dtManager = dtManager
 		return nil
 	}
 }

--- a/option.go
+++ b/option.go
@@ -6,9 +6,14 @@ import (
 	"time"
 
 	dt "github.com/filecoin-project/go-data-transfer"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
+
+type blockHookRegister interface {
+	RegisterIncomingBlockHook(graphsync.OnIncomingBlockHook) graphsync.UnregisterHookFunc
+}
 
 // config contains all options for configuring Subscriber.
 type config struct {
@@ -16,8 +21,10 @@ type config struct {
 	allowPeer AllowPeerFunc
 
 	topic *pubsub.Topic
-	// TODO figure out how to register a block hook with an existing dtManager
-	dtManager  dt.Manager
+
+	dtManager     dt.Manager
+	graphExchange graphsync.GraphExchange
+
 	blockHook  BlockHookFunc
 	httpClient *http.Client
 
@@ -63,9 +70,10 @@ func Topic(topic *pubsub.Topic) Option {
 }
 
 // DtManager provides an existing datatransfer manager.
-func DtManager(dtManager dt.Manager) Option {
+func DtManager(dtManager dt.Manager, gs graphsync.GraphExchange) Option {
 	return func(c *config) error {
 		c.dtManager = dtManager
+		c.graphExchange = gs
 		return nil
 	}
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -186,7 +186,17 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 	scopedBlockHookMutex, scopedBlockHook, blockHook := wrapBlockHook(cfg.blockHook)
 
 	var dtSync *dtsync.Sync
-	dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
+	if cfg.dtManager != nil {
+		if ds != nil {
+			log.Warn("Datastore cannot be used with DtManager option")
+		}
+		if cfg.blockHook != nil {
+			log.Warn("BlockHook option cannot be used with DtManager option")
+		}
+		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager)
+	} else {
+		dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
+	}
 	if err != nil {
 		cancelPubsub()
 		return nil, err

--- a/subscriber.go
+++ b/subscriber.go
@@ -188,12 +188,10 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 	var dtSync *dtsync.Sync
 	if cfg.dtManager != nil {
 		if ds != nil {
-			log.Warn("Datastore cannot be used with DtManager option")
+			cancelPubsub()
+			return nil, fmt.Errorf("datastore cannot be used with DtManager option")
 		}
-		if cfg.blockHook != nil {
-			log.Warn("BlockHook option cannot be used with DtManager option")
-		}
-		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager)
+		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager, cfg.graphExchange, blockHook)
 	} else {
 		dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.5"
+  "version": "v0.3.6"
 }


### PR DESCRIPTION
Without this option, if a process uses a go-legs subscriber, it cannot expose a graphsync instance on the same libp2p host.

There can only be a single stream handler for a protocol ID and graphsync instantiation sets it for "/ipfs/graphsync/1.0.0" this protocol ID.  So we need this option back?
