### PR TITLE
Generalize CheckAlreadySynced

### DIFF
--- a/option.go
+++ b/option.go
@@ -88,7 +88,6 @@ func SyncRecursionLimit(limit selector.RecursionLimit) Option {
 
 type syncCfg struct {
 	alwaysUpdateLatest bool
-	checkAlreadySynced bool
 	scopedBlockHook    BlockHookFunc
 }
 
@@ -97,16 +96,6 @@ type SyncOption func(*syncCfg)
 func AlwaysUpdateLatest() SyncOption {
 	return func(sc *syncCfg) {
 		sc.alwaysUpdateLatest = true
-	}
-}
-
-// CheckAlreadySynced is used when a custom selector is provided, and checks if
-// the head node returned from the publisher is the latest seen.  This is
-// needed because a selector with a stop node only recognizes if the previous
-// link is the stop, not if the current node is.
-func CheckAlreadySynced() SyncOption {
-	return func(sc *syncCfg) {
-		sc.checkAlreadySynced = true
 	}
 }
 

--- a/selector.go
+++ b/selector.go
@@ -1,6 +1,8 @@
 package legs
 
 import (
+	"fmt"
+
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -56,6 +58,9 @@ func ExploreRecursiveWithStopNode(limit selector.RecursionLimit, sequence ipld.N
 
 // getStopNode will try to return the stop node from a recursive selector.
 func getStopNode(selNode datamodel.Node) (datamodel.Link, error) {
+	if selNode == nil {
+		return nil, fmt.Errorf("nil selector")
+	}
 	selNode, err := selNode.LookupByString(selector.SelectorKey_ExploreRecursive)
 	if err != nil {
 		return nil, err

--- a/selector.go
+++ b/selector.go
@@ -2,6 +2,7 @@ package legs
 
 import (
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -51,6 +52,23 @@ func ExploreRecursiveWithStopNode(limit selector.RecursionLimit, sequence ipld.N
 			}
 		})
 	})
+}
+
+// getStopNode will try to return the stop node from a recursive selector.
+func getStopNode(selNode datamodel.Node) (datamodel.Link, error) {
+	selNode, err := selNode.LookupByString(selector.SelectorKey_ExploreRecursive)
+	if err != nil {
+		return nil, err
+	}
+	selNode, err = selNode.LookupByString(selector.SelectorKey_StopAt)
+	if err != nil {
+		return nil, err
+	}
+	selNode, err = selNode.LookupByString(string(selector.ConditionMode_Link))
+	if err != nil {
+		return nil, err
+	}
+	return selNode.AsLink()
 }
 
 // LegSelector is a convenient function that returns the selector

--- a/selector.go
+++ b/selector.go
@@ -1,8 +1,6 @@
 package legs
 
 import (
-	"fmt"
-
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -57,23 +55,24 @@ func ExploreRecursiveWithStopNode(limit selector.RecursionLimit, sequence ipld.N
 }
 
 // getStopNode will try to return the stop node from a recursive selector.
-func getStopNode(selNode datamodel.Node) (datamodel.Link, error) {
+func getStopNode(selNode datamodel.Node) (datamodel.Link, bool) {
 	if selNode == nil {
-		return nil, fmt.Errorf("nil selector")
+		return nil, false
 	}
 	selNode, err := selNode.LookupByString(selector.SelectorKey_ExploreRecursive)
 	if err != nil {
-		return nil, err
+		return nil, false
 	}
 	selNode, err = selNode.LookupByString(selector.SelectorKey_StopAt)
 	if err != nil {
-		return nil, err
+		return nil, false
 	}
 	selNode, err = selNode.LookupByString(string(selector.ConditionMode_Link))
 	if err != nil {
-		return nil, err
+		return nil, false
 	}
-	return selNode.AsLink()
+	stopNodeLink, err := selNode.AsLink()
+	return stopNodeLink, err == nil
 }
 
 // LegSelector is a convenient function that returns the selector

--- a/selector_test.go
+++ b/selector_test.go
@@ -14,13 +14,13 @@ func TestGetStopNode(t *testing.T) {
 	require.NoError(t, err)
 	stopNode := cidlink.Link{Cid: c}
 	sel := ExploreRecursiveWithStopNode(selector.RecursionLimitNone(), nil, stopNode)
-	actualStopNode, err := getStopNode(sel)
-	require.NoError(t, err)
+	actualStopNode, ok := getStopNode(sel)
+	require.True(t, ok)
 	require.Equal(t, stopNode, actualStopNode)
 }
 
 func TestGetStopNodeWhenNil(t *testing.T) {
 	sel := ExploreRecursiveWithStopNode(selector.RecursionLimitNone(), nil, nil)
-	_, err := getStopNode(sel)
-	require.Error(t, err, "We shouldn't get a stop node out if none was set")
+	_, ok := getStopNode(sel)
+	require.False(t, ok, "We shouldn't get a stop node out if none was set")
 }

--- a/selector_test.go
+++ b/selector_test.go
@@ -1,0 +1,26 @@
+package legs
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStopNode(t *testing.T) {
+	c, err := cid.V0Builder{}.Sum([]byte("hi"))
+	require.NoError(t, err)
+	stopNode := cidlink.Link{Cid: c}
+	sel := ExploreRecursiveWithStopNode(selector.RecursionLimitNone(), nil, stopNode)
+	actualStopNode, err := getStopNode(sel)
+	require.NoError(t, err)
+	require.Equal(t, stopNode, actualStopNode)
+}
+
+func TestGetStopNodeWhenNil(t *testing.T) {
+	sel := ExploreRecursiveWithStopNode(selector.RecursionLimitNone(), nil, nil)
+	_, err := getStopNode(sel)
+	require.Error(t, err, "We shouldn't get a stop node out if none was set")
+}

--- a/subscriber.go
+++ b/subscriber.go
@@ -478,7 +478,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 	hnd.syncMutex.Lock()
 	defer hnd.syncMutex.Unlock()
 
-	err = hnd.handle(ctx, nextCid, sel, wrapSel, updateLatest, syncer, cfg.scopedBlockHook, cfg.checkAlreadySynced)
+	err = hnd.handle(ctx, nextCid, sel, wrapSel, updateLatest, syncer, cfg.scopedBlockHook)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("sync handler failed: %w", err)
 	}
@@ -643,7 +643,7 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, ss ipld.Node
 		select {
 		case <-ctx.Done():
 		case c := <-h.msgChan:
-			err := h.handle(ctx, c, ss, true, true, h.subscriber.dtSync.NewSyncer(h.peerID, h.subscriber.topicName), nil, false)
+			err := h.handle(ctx, c, ss, true, true, h.subscriber.dtSync.NewSyncer(h.peerID, h.subscriber.topicName), nil)
 			if err != nil {
 				// Log error for now.
 				log.Errorw("Cannot process message", "err", err, "peer", h.peerID)
@@ -660,7 +660,7 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, ss ipld.Node
 // handle processes a message from the peer that the handler is responsible for.
 // The caller is responsible for ensuring that this is called while h.syncMutex
 // is locked.
-func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel, updateLatest bool, syncer Syncer, hook BlockHookFunc, checkAlreadySynced bool) error {
+func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel, updateLatest bool, syncer Syncer, hook BlockHookFunc) error {
 	log := log.With("cid", nextCid, "peer", h.peerID)
 
 	// This is not set to nil so we can get a pointer.
@@ -676,24 +676,13 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 	}()
 
 	if wrapSel {
-		// Note this branch is nested under wrapSel because wrapSel adds the
-		// semantics that we stop when we hit the `h.latestSync` node. This is
-		// a special case where we are starting at the stop node so we can just
-		// return.
-		if h.latestSync != nil && h.latestSync.(cidlink.Link).Cid == nextCid {
-			// Nothing to do. We've already synced to this cid because we have
-			// it as h.latestSync.
-			log.Infow("Already synced")
-			return nil
-		}
-
 		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
-	} else if checkAlreadySynced {
-		// Special case when starting at stop node; selector does not check it.
-		if h.latestSync != nil && h.latestSync.(cidlink.Link).Cid == nextCid {
-			// Nothing to do. We've already synced to this cid because we have
-			// it as h.latestSync.
-			log.Infow("Already synced")
+	}
+
+	if sel != nil {
+		stopNode, err := getStopNode(sel)
+		if err == nil && stopNode.(cidlink.Link).Cid == nextCid {
+			log.Infow("cid to sync to is the stop node. Nothing to do")
 			return nil
 		}
 	}

--- a/subscriber.go
+++ b/subscriber.go
@@ -679,13 +679,13 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
 	}
 
-	stopNode, err := getStopNode(sel)
-	if err == nil && stopNode.(cidlink.Link).Cid == nextCid {
+	stopNode, ok := getStopNode(sel)
+	if ok && stopNode.(cidlink.Link).Cid == nextCid {
 		log.Infow("cid to sync to is the stop node. Nothing to do")
 		return nil
 	}
 
-	err = syncer.Sync(ctx, nextCid, sel)
+	err := syncer.Sync(ctx, nextCid, sel)
 	if err != nil {
 		return err
 	}

--- a/subscriber.go
+++ b/subscriber.go
@@ -679,15 +679,13 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
 	}
 
-	if sel != nil {
-		stopNode, err := getStopNode(sel)
-		if err == nil && stopNode.(cidlink.Link).Cid == nextCid {
-			log.Infow("cid to sync to is the stop node. Nothing to do")
-			return nil
-		}
+	stopNode, err := getStopNode(sel)
+	if err == nil && stopNode.(cidlink.Link).Cid == nextCid {
+		log.Infow("cid to sync to is the stop node. Nothing to do")
+		return nil
 	}
 
-	err := syncer.Sync(ctx, nextCid, sel)
+	err = syncer.Sync(ctx, nextCid, sel)
 	if err != nil {
 		return err
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.4"
+  "version": "v0.3.5"
 }


### PR DESCRIPTION
## Context
When the stop node in the recursive selector is the same as our sync node, we will never stop early because the stop node is only checked after traversal has started. 

We previously did a check to see if our sync cid was our latestSync and exit early. This is a special case of the more general form where the stop node in the selector is the cid of the node we are going to start traversal on.

Then we added a special flag to always do this special case.

## Proposed Solution

Instead of having the user remember to pass in the flag for the special case check, lets try to determine if we're already in the case where we are trying to stop on the same cid as where we are starting.

Note that this uses knowledge of the Recursive Selector structure to get the stop node. There's a test that will break if this knowledge is ever wrong. It's not ideal, but I think it's better than having to remember to pass in the special flag.
