### PR TITLE
Specify alternate recursion limit for trusted peers

### DIFF
--- a/legs_test.go
+++ b/legs_test.go
@@ -74,8 +74,8 @@ func TestAllowPeerReject(t *testing.T) {
 
 	// Set function to reject anything except dstHost, which is not the one
 	// generating the update.
-	sub.SetAllowPeer(func(peerID peer.ID) (bool, error) {
-		return peerID == dstHost.ID(), nil
+	sub.SetAllowPeer(func(peerID peer.ID) bool {
+		return peerID == dstHost.ID()
 	})
 
 	watcher, cncl := sub.OnSyncFinished()
@@ -110,8 +110,8 @@ func TestAllowPeerAllows(t *testing.T) {
 	defer sub.Close()
 
 	// Set function to allow any peer.
-	sub.SetAllowPeer(func(peerID peer.ID) (bool, error) {
-		return true, nil
+	sub.SetAllowPeer(func(peerID peer.ID) bool {
+		return true
 	})
 
 	watcher, cncl := sub.OnSyncFinished()

--- a/selector.go
+++ b/selector.go
@@ -22,12 +22,11 @@ func ExploreRecursiveWithStop(limit selector.RecursionLimit, sequence selectorbu
 func ExploreRecursiveWithStopNode(limit selector.RecursionLimit, sequence ipld.Node, stopLnk ipld.Link) ipld.Node {
 	if sequence == nil {
 		log.Debug("No selector sequence specified; using default explore all with recursive edge.")
-		np := basicnode.Prototype__Any{}
-		ssb := selectorbuilder.NewSelectorSpecBuilder(np)
+		ssb := selectorbuilder.NewSelectorSpecBuilder(basicnode.Prototype__Any{})
 		sequence = ssb.ExploreAll(ssb.ExploreRecursiveEdge()).Node()
 	}
-	np := basicnode.Prototype__Map{}
-	return fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
+
+	return fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
 		// RecursionLimit
 		na.AssembleEntry(selector.SelectorKey_ExploreRecursive).CreateMap(3, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_Limit).CreateMap(1, func(na fluent.MapAssembler) {


### PR DESCRIPTION
If a peer is trusted then it will use a different recursion limit than an untrusted host. A function to determine if the host is trusted, and the trusted resursion limit can be specified using a subscriber option.