### PR TITLE
Implement rate limiting for subscribers

### DIFF
--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -130,11 +130,6 @@ func (s *Sync) addRateLimiting(bFn graphsync.OnIncomingBlockHook, rateLimiter ra
 		lastFailedBlock, isRetryingDueToRateLimit := s.isRetryingDueToRateLimit.Load(p)
 		if isRetryingDueToRateLimit && lastFailedBlock == blockData.Link().(cidlink.Link).Cid {
 			s.isRetryingDueToRateLimit.Delete(p)
-		} else if isRetryingDueToRateLimit {
-			// We're in a retry loop due to rate limiting and we haven't seen the
-			// block that we stopped at before, so we won't call the wrapped block
-			// hook. This is because we already called it in a previous iteration of this sync.
-			return
 		}
 
 		if bFn != nil {

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -8,13 +8,15 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
+	rate "golang.org/x/time/rate"
 )
 
 // Syncer handles a single sync with a provider.
 type Syncer struct {
-	peerID    peer.ID
-	sync      *Sync
-	topicName string
+	peerID      peer.ID
+	sync        *Sync
+	topicName   string
+	rateLimiter *rate.Limiter
 }
 
 // GetHead queries a provider for the latest CID.
@@ -25,17 +27,44 @@ func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
 // Sync opens a datatransfer data channel and uses the selector to pull data
 // from the provider.
 func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error {
-	syncDone := s.sync.notifyOnSyncDone(inProgressSyncKey{nextCid, s.peerID})
-
-	log.Debugw("Starting data channel for message source", "cid", nextCid, "source_peer", s.peerID)
-
-	v := Voucher{&nextCid}
-	_, err := s.sync.dtManager.OpenPullDataChannel(ctx, s.peerID, &v, nextCid, sel)
-	if err != nil {
-		s.sync.signalSyncDone(inProgressSyncKey{nextCid, s.peerID}, nil)
-		return fmt.Errorf("cannot open data channel: %w", err)
+	if s.rateLimiter != nil {
+		// We were passed in a specific rate limiter, let's use it instead of the default one.
+		s.sync.overrideRateLimiterForMu.Lock()
+		// In case there was a previous rate limiter override.
+		originalOverrideRateLimiter := s.sync.overrideRateLimiterFor[s.peerID]
+		s.sync.overrideRateLimiterFor[s.peerID] = s.rateLimiter
+		s.sync.overrideRateLimiterForMu.Unlock()
+		defer func() {
+			s.sync.overrideRateLimiterForMu.Lock()
+			s.sync.overrideRateLimiterFor[s.peerID] = originalOverrideRateLimiter
+			s.sync.overrideRateLimiterForMu.Unlock()
+		}()
 	}
 
-	// Wait for transfer finished signal.
-	return <-syncDone
+	inProgressSyncK := inProgressSyncKey{nextCid, s.peerID}
+
+	for {
+		// For loop to retry if we get rate limited.
+		syncDone := s.sync.notifyOnSyncDone(inProgressSyncK)
+
+		log.Debugw("Starting data channel for message source", "cid", nextCid, "source_peer", s.peerID)
+
+		v := Voucher{&nextCid}
+		_, err := s.sync.dtManager.OpenPullDataChannel(ctx, s.peerID, &v, nextCid, sel)
+		if err != nil {
+			s.sync.signalSyncDone(inProgressSyncK, nil)
+			return fmt.Errorf("cannot open data channel: %w", err)
+		}
+
+		// Wait for transfer finished signal.
+		err = <-syncDone
+		if _, ok := err.(rateLimitErr); ok {
+			log.Infow("hit rate limit. Waiting and will retry later", "cid", nextCid, "source_peer", s.peerID)
+
+			// Wait until we've fully refilled our rate limit bucket since this is a relatively heavy operation (essentially restarting the sync).
+			s.rateLimiter.WaitN(ctx, s.rateLimiter.Burst())
+			continue
+		}
+		return err
+	}
 }

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -62,7 +62,10 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 
 			// Wait until we've fully refilled our rate limit bucket since this is a
 			// relatively heavy operation (essentially restarting the sync).
-			s.rateLimiter.WaitN(ctx, s.rateLimiter.Burst())
+			waitErr := s.rateLimiter.WaitN(ctx, s.rateLimiter.Burst())
+			if waitErr != nil {
+				return err
+			}
 
 			// Set the nextCid to be the cid that we stopped at becasuse of rate
 			// limitting. This lets us pick up where we left off

--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.sum
+++ b/go.sum
@@ -1497,6 +1497,7 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -590,6 +590,7 @@ func TestRateLimiter(t *testing.T) {
 			start := time.Now()
 			_, err = sub.Sync(context.Background(), pubHostSys.host.ID(), cid.Undef, nil, pubAddr)
 			require.NoError(t, err)
+			// Minus 1 because we start with a full bucket.
 			require.GreaterOrEqual(t, time.Since(start), tokenEvery*time.Duration(llB.Length-1))
 
 			require.Equal(t, atomic.LoadInt64(&calledTimes), int64(llB.Length))

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -541,6 +542,58 @@ func TestHttpPeerAddrPeerstore(t *testing.T) {
 	_, err = sub.Sync(context.Background(), pubHostSys.host.ID(), cid.Undef, nil, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+}
+
+func TestRateLimiter(t *testing.T) {
+	type testCase struct {
+		name   string
+		isHttp bool
+	}
+
+	testCases := []testCase{
+		{"DT rate limiter", false},
+		{"HTTP rate limiter", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			pubHostSys := newHostSystem(t)
+			subHostSys := newHostSystem(t)
+
+			tokenEvery := 100 * time.Millisecond
+			limiter := rate.NewLimiter(rate.Every(tokenEvery), 1)
+			var calledTimes int64
+			pubAddr, pub, sub := legsPubSubBuilder{
+				IsHttp: tc.isHttp,
+			}.Build(t, testTopic, pubHostSys, subHostSys, []legs.Option{
+				legs.BlockHook(func(i peer.ID, c cid.Cid) {
+					atomic.AddInt64(&calledTimes, 1)
+				}),
+				legs.RateLimiter(func(publisher peer.ID) *rate.Limiter {
+					return limiter
+				}),
+			})
+
+			llB := llBuilder{
+				Length: 5,
+			}
+			ll := llB.Build(t, pubHostSys.lsys)
+
+			err := pub.SetRoot(context.Background(), ll.(cidlink.Link).Cid)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			start := time.Now()
+			_, err = sub.Sync(context.Background(), pubHostSys.host.ID(), cid.Undef, nil, pubAddr)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, time.Since(start), tokenEvery*time.Duration(llB.Length-1))
+
+			require.Equal(t, atomic.LoadInt64(&calledTimes), int64(llB.Length))
+		})
 	}
 
 }


### PR DESCRIPTION
## Context

We'd like for a subscriber to be able to specify a rate limit for publishers sending messages to the subscriber. This is so that we can safely sync an arbitrary long chain of data from a publisher and  know that this sync isn't going to prevent the caller from being able to get other work done.

The caller simply starts a sync like normal, and go-legs will sync will adhering to the rate limit.

## Proposed change

The caller is now able to pass in a rate limiter to limit how often we fetch new data from a publisher. The caller may also pass in a different rate limiter for a manual sync (as opposed to the background async updates).

This is change is in two parts because we have the http and data transfer syncer.

1. The http syncer is will check the rate limiter before fetching a remote block over http. If no tokens are available it'll wait until there is an available token.
2. The DT syncer is more complicated since I wasn't able to get `hookActions.PauseRequest` to work.
    * If we hit a rate limit we fail the datatransfer and restart it from where we left off once all our tokens have refilled.

## Tests

This adds a new test to verify rate limiting in both sync impls.
