### PR TITLE
Better error if we cannot query head for sync

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -480,7 +480,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 		// Query the peer for the latest CID
 		nextCid, err = syncer.GetHead(ctx)
 		if err != nil {
-			return cid.Undef, fmt.Errorf("cannot query head for sync: %w", err)
+			return cid.Undef, fmt.Errorf("cannot query head for sync: %w. Possibly incorrect topic configured", err)
 		}
 
 		// Check if there is a latest CID.


### PR DESCRIPTION
## Context
I've run into the error: `cannot query head for sync: Get \"http://unused.invalid/head\": protocol not supported` multiple times and it's almost always that the topic is configured differently. Which the error does not mention.

## Proposed change

Include a hint that the topic may be misconfigured in the error.
