### PR TITLE
Fix rate limit burst refresh for graphsync

### DIFF
--- a/legs_test.go
+++ b/legs_test.go
@@ -74,8 +74,8 @@ func TestAllowPeerReject(t *testing.T) {
 
 	// Set function to reject anything except dstHost, which is not the one
 	// generating the update.
-	sub.SetAllowPeer(func(peerID peer.ID) (bool, error) {
-		return peerID == dstHost.ID(), nil
+	sub.SetAllowPeer(func(peerID peer.ID) bool {
+		return peerID == dstHost.ID()
 	})
 
 	watcher, cncl := sub.OnSyncFinished()
@@ -110,8 +110,8 @@ func TestAllowPeerAllows(t *testing.T) {
 	defer sub.Close()
 
 	// Set function to allow any peer.
-	sub.SetAllowPeer(func(peerID peer.ID) (bool, error) {
-		return true, nil
+	sub.SetAllowPeer(func(peerID peer.ID) bool {
+		return true
 	})
 
 	watcher, cncl := sub.OnSyncFinished()


### PR DESCRIPTION
After dt/gs session hits the burst limit, it is necessary wait for the token bucket to refil before restarting the session. The wait was happening but was also emptying its bucket.  So when the session restarted there was no burst and rate limiting would happen immidiately after reading the next block or two.  This fixes this to wait without emptying the bucket.

Other changes:
- Improved logging
- AllowPeerFunc only retruns bool. It is up to the function to log any errors, not legs.  Also returning the error does not allow any decision beyond what the boolean return value already does.