### PR TITLE
Simplify rate limiter configuration

### DIFF
--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -27,9 +27,6 @@ type inProgressSyncKey struct {
 	peer peer.ID
 }
 
-// purposely a type alias
-type rateLimiterFor = func(publisher peer.ID) *rate.Limiter
-
 // Sync provides sync functionality for use with all datatransfer syncs.
 type Sync struct {
 	dtManager   dt.Manager
@@ -109,7 +106,7 @@ func (s *Sync) getRateLimiter(peerID peer.ID) *rate.Limiter {
 	return limiter
 }
 
-func (s *Sync) addRateLimiting(bFn graphsync.OnIncomingBlockHook, rateLimiter rateLimiterFor, gs graphsync.GraphExchange) graphsync.OnIncomingBlockHook {
+func (s *Sync) addRateLimiting(bFn graphsync.OnIncomingBlockHook, rateLimiter func(peer.ID) *rate.Limiter, gs graphsync.GraphExchange) graphsync.OnIncomingBlockHook {
 	return func(p peer.ID, responseData graphsync.ResponseData, blockData graphsync.BlockData, hookActions graphsync.IncomingBlockHookActions) {
 		isLocalBlock := blockData.BlockSizeOnWire() == 0
 

--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -50,7 +50,11 @@ type Sync struct {
 // NewSyncWithDT creates a new Sync with a datatransfer.Manager provided by the
 // caller.
 func NewSyncWithDT(host host.Host, dtManager dt.Manager, gs graphsync.GraphExchange, blockHook func(peer.ID, cid.Cid), limiterFor rateLimiterFor) (*Sync, error) {
-	registerVoucher(dtManager, &Voucher{}, nil)
+	err := registerVoucher(dtManager, &Voucher{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	s := &Sync{
 		host:       host,
 		dtManager:  dtManager,

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -29,6 +29,8 @@ func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
 // from the provider.
 func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error {
 	if s.rateLimiter != nil {
+		// Remove peer rate limiter set in call to getRateLimiter, called from
+		// wrapped block hook.
 		defer s.sync.clearRateLimiter(s.peerID)
 	}
 

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -29,8 +29,10 @@ func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
 // from the provider.
 func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error {
 	if s.rateLimiter != nil {
-		// Remove peer rate limiter set in call to getRateLimiter, called from
-		// wrapped block hook.
+		// Set the rate limiter to use for this sync of the peer. This limiter
+		// is retrieved by getRateLimiter, called from wrapped block hook.
+		s.sync.setRateLimiter(s.peerID, s.rateLimiter)
+		// Remove rate limiter set above.
 		defer s.sync.clearRateLimiter(s.peerID)
 	}
 

--- a/httpsync/sync.go
+++ b/httpsync/sync.go
@@ -29,9 +29,6 @@ const defaultHttpTimeout = 10 * time.Second
 
 var log = logging.Logger("go-legs-httpsync")
 
-// purposely a type alias
-type rateLimiterFor = func(publisher peer.ID) *rate.Limiter
-
 // Sync provides sync functionality for use with all http syncs.
 type Sync struct {
 	blockHook func(peer.ID, cid.Cid)

--- a/option.go
+++ b/option.go
@@ -6,14 +6,13 @@ import (
 	"sync"
 	"time"
 
-	rate "golang.org/x/time/rate"
-
 	dt "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"golang.org/x/time/rate"
 )
 
 // config contains all options for configuring Subscriber.
@@ -127,6 +126,8 @@ func SyncRecursionLimit(limit selector.RecursionLimit) Option {
 
 type RateLimiterFor func(publisher peer.ID) *rate.Limiter
 
+// RateLimiter configures a function that is called for each sync to get the
+// rate limiter for a specific peer.
 func RateLimiter(limiterFor RateLimiterFor) Option {
 	return func(c *config) error {
 		c.rateLimiterFor = limiterFor
@@ -169,7 +170,6 @@ func UseLatestSyncHandler(h LatestSyncHandler) Option {
 type syncCfg struct {
 	alwaysUpdateLatest bool
 	scopedBlockHook    BlockHookFunc
-	rateLimiter        *rate.Limiter
 	segDepthLimit      int64
 }
 
@@ -191,12 +191,6 @@ func AlwaysUpdateLatest() SyncOption {
 func ScopedBlockHook(hook BlockHookFunc) SyncOption {
 	return func(sc *syncCfg) {
 		sc.scopedBlockHook = hook
-	}
-}
-
-func ScopedRateLimiter(l *rate.Limiter) SyncOption {
-	return func(sc *syncCfg) {
-		sc.rateLimiter = l
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -169,6 +169,7 @@ func UseLatestSyncHandler(h LatestSyncHandler) Option {
 
 type syncCfg struct {
 	alwaysUpdateLatest bool
+	rateLimiter        *rate.Limiter
 	scopedBlockHook    BlockHookFunc
 	segDepthLimit      int64
 }
@@ -181,25 +182,35 @@ func AlwaysUpdateLatest() SyncOption {
 	}
 }
 
-// ScopedBlockHook is the equivalent of BlockHook option but only applied to a single sync.
-// If not specified, the Subscriber BlockHook option is used instead.
-// Specifying the ScopedBlockHook will override the Subscriber level BlockHook for the current
-// sync.
-// Note that calls to SegmentSyncActions from bloc hook will have no impact if segmented sync is
-// disabled.
-// See: BlockHook, SegmentDepthLimit, ScopedSegmentDepthLimit.
+// ScopedBlockHook is the equivalent of BlockHook option but only applied to a
+// single sync. If not specified, the Subscriber BlockHook option is used
+// instead. Specifying the ScopedBlockHook will override the Subscriber level
+// BlockHook for the current sync.
+//
+// Note that calls to SegmentSyncActions from bloc hook will have no impact if
+// segmented sync is disabled. See: BlockHook, SegmentDepthLimit,
+// ScopedSegmentDepthLimit.
 func ScopedBlockHook(hook BlockHookFunc) SyncOption {
 	return func(sc *syncCfg) {
 		sc.scopedBlockHook = hook
 	}
 }
 
-// ScopedSegmentDepthLimit is the equivalent of SegmentDepthLimit option but only applied to a
-// single sync.
-// If not specified, the Subscriber SegmentDepthLimit option is used instead.
-// Note that for segmented sync to function at least one of BlockHook or ScopedBlockHook must be
-// set.
-// See: SegmentDepthLimit.
+// ScopedRateLimiter set a rate limiter to use for a singel sync. If not
+// specified, the Subscriber rateLimiterFor function is used to get a rate
+// limiter for the sync.
+func ScopedRateLimiter(l *rate.Limiter) SyncOption {
+	return func(sc *syncCfg) {
+		sc.rateLimiter = l
+	}
+}
+
+// ScopedSegmentDepthLimit is the equivalent of SegmentDepthLimit option but
+// only applied to a single sync. If not specified, the Subscriber
+// SegmentDepthLimit option is used instead.
+//
+// Note that for segmented sync to function at least one of BlockHook or
+// ScopedBlockHook must be set. See: SegmentDepthLimit.
 func ScopedSegmentDepthLimit(depth int64) SyncOption {
 	return func(sc *syncCfg) {
 		sc.segDepthLimit = depth

--- a/subscriber.go
+++ b/subscriber.go
@@ -663,6 +663,10 @@ func (s *Subscriber) makeSyncer(peerID peer.ID, peerAddrs []multiaddr.Multiaddr,
 	}
 
 	if httpAddr != nil {
+		// Store this http address so that future calls to sync will work without a
+		// peerAddr (given that it happens within the TTL)
+		s.httpPeerstore.AddAddr(peerID, httpAddr, addrTTL)
+
 		syncer, err := s.httpSync.NewSyncer(peerID, httpAddr, rateLimiter)
 		if err != nil {
 			return nil, false, fmt.Errorf("cannot create http sync handler: %w", err)

--- a/subscriber.go
+++ b/subscriber.go
@@ -429,6 +429,9 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 		peerAddrs = []multiaddr.Multiaddr{peerAddr}
 	}
 	syncer, isHttp, err := s.makeSyncer(peerID, peerAddrs, tempAddrTTL)
+	if err != nil {
+		return cid.Undef, err
+	}
 
 	updateLatest := cfg.alwaysUpdateLatest
 	if nextCid == cid.Undef {

--- a/sync_test.go
+++ b/sync_test.go
@@ -29,6 +29,8 @@ func TestLatestSyncSuccess(t *testing.T) {
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
+	defer srcHost.Close()
+	defer dstHost.Close()
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -74,6 +76,8 @@ func TestSyncFn(t *testing.T) {
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
+	defer srcHost.Close()
+	defer dstHost.Close()
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -208,6 +212,9 @@ func TestPartialSync(t *testing.T) {
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
 
+	defer srcHost.Close()
+	defer dstHost.Close()
+
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]))
@@ -275,6 +282,8 @@ func TestStepByStepSync(t *testing.T) {
 
 	srcHost := test.MkTestHost()
 	dstHost := test.MkTestHost()
+	defer srcHost.Close()
+	defer dstHost.Close()
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -317,6 +326,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcHost := test.MkTestHost()
+	defer srcHost.Close()
 	srcLnkS := test.MkLinkSystem(srcStore)
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
 	if err != nil {
@@ -327,6 +337,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	chainLnks := test.MkChain(srcLnkS, true)
 
 	dstHost := test.MkTestHost()
+	defer dstHost.Close()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
@@ -385,8 +396,9 @@ func TestAnnounce(t *testing.T) {
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcHost := test.MkTestHost()
 	srcLnkS := test.MkLinkSystem(srcStore)
-
 	dstHost := test.MkTestHost()
+	defer srcHost.Close()
+	defer dstHost.Close()
 
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)

--- a/test/util.go
+++ b/test/util.go
@@ -106,7 +106,10 @@ func WaitForMeshWithMessage(t *testing.T, topic string, hosts ...host.Host) []*p
 			// Wait until someone else picks up this topic and sends a message before
 			// we cancel. This way the topic isn't unsubscribed to before we start
 			// the test.
-			s.Next(context.Background())
+			_, err = s.Next(context.Background())
+			if err != nil {
+				fmt.Println("error getting next message on subscription:", err)
+			}
 			s.Cancel()
 		}(s)
 	}


### PR DESCRIPTION
### Set rate limiter to use for sync only when creating Syncer
When doing a sync, set the rate limiter to the one provided for that individual sync, or if one was not provided, get it from the Subscriber's `rateLimiterFor` function if that function is available.

### Specifying a nil rate limiter is now OK
It is not necessary to construct an infinite rate limiter when there is no rate-limiting. A `nil` rate limiter avoids any rate-limiting logic.

### Stabilize tests by closing libp2p host connections
Tests were failing on some systems due to an error "socket: too many open files". This was caused by libp2p hosts having connections that were not closed. Tests have been modified to close the connections.

Also contains fix for #132 