### PR TITLE
Fix derived protocol ID so there are no double slashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.6.1
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multicodec v0.4.0
+	github.com/multiformats/go-multistream v0.2.2
 	github.com/stretchr/testify v1.7.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
@@ -122,7 +123,6 @@ require (
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
 	github.com/multiformats/go-multihash v0.1.0 // indirect
-	github.com/multiformats/go-multistream v0.2.2 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect

--- a/p2p/protocol/head/head_test.go
+++ b/p2p/protocol/head/head_test.go
@@ -1,4 +1,4 @@
-package head
+package head_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-legs/p2p/protocol/head"
 	"github.com/filecoin-project/go-legs/test"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -47,14 +48,14 @@ func TestFetchLatestHead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := NewPublisher()
+	p := head.NewPublisher()
 	go p.Serve(publisher, "test")
 	defer p.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c, err := QueryRootCid(ctx, client, "test", publisher.ID())
+	c, err := head.QueryRootCid(ctx, client, "test", publisher.ID())
 	if err != nil && c != cid.Undef {
 		t.Fatal("Expected to get a nil error and a cid undef because there is no root")
 	}
@@ -63,19 +64,12 @@ func TestFetchLatestHead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = QueryRootCid(ctx, client, "test", publisher.ID())
+	c, err = head.QueryRootCid(ctx, client, "test", publisher.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if !c.Equals(rootLnk.(cidlink.Link).Cid) {
 		t.Fatalf("didn't get expected cid. expected %s, got %s", rootLnk, c)
-	}
-}
-
-func TestDeriveProtocolID(t *testing.T) {
-	protoID := deriveProtocolID("/mainnet")
-	if strings.Contains(string(protoID), "//") {
-		t.Fatalf("Derived protocol ID %q should not contain \"//\"", protoID)
 	}
 }

--- a/p2p/protocol/head/head_test.go
+++ b/p2p/protocol/head/head_test.go
@@ -1,4 +1,4 @@
-package head_test
+package head
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-legs/p2p/protocol/head"
 	"github.com/filecoin-project/go-legs/test"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -48,14 +47,14 @@ func TestFetchLatestHead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := head.NewPublisher()
+	p := NewPublisher()
 	go p.Serve(publisher, "test")
 	defer p.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c, err := head.QueryRootCid(ctx, client, "test", publisher.ID())
+	c, err := QueryRootCid(ctx, client, "test", publisher.ID())
 	if err != nil && c != cid.Undef {
 		t.Fatal("Expected to get a nil error and a cid undef because there is no root")
 	}
@@ -64,12 +63,19 @@ func TestFetchLatestHead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = head.QueryRootCid(ctx, client, "test", publisher.ID())
+	c, err = QueryRootCid(ctx, client, "test", publisher.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if !c.Equals(rootLnk.(cidlink.Link).Cid) {
 		t.Fatalf("didn't get expected cid. expected %s, got %s", rootLnk, c)
+	}
+}
+
+func TestDeriveProtocolID(t *testing.T) {
+	protoID := deriveProtocolID("/mainnet")
+	if strings.Contains(string(protoID), "//") {
+		t.Fatalf("Derived protocol ID %q should not contain \"//\"", protoID)
 	}
 }

--- a/p2p/protocol/head/internal_test.go
+++ b/p2p/protocol/head/internal_test.go
@@ -1,0 +1,13 @@
+package head
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeriveProtocolID(t *testing.T) {
+	protoID := deriveProtocolID("/mainnet")
+	if strings.Contains(string(protoID), "//") {
+		t.Fatalf("Derived protocol ID %q should not contain \"//\"", protoID)
+	}
+}


### PR DESCRIPTION
When the head client connects to a libp2p server and receives a "protocol not supported" error, it will try the old double-slashed protocol ID.

Fixes #86