### PR TITLE
Convert multiaddr to URL should handle /tls

### DIFF
--- a/httpsync/multiaddr/convert.go
+++ b/httpsync/multiaddr/convert.go
@@ -68,7 +68,20 @@ func ToURL(ma multiaddr.Multiaddr) (*url.URL, error) {
 	scheme := "http"
 	if _, ok := pm[multiaddr.P_HTTPS]; ok {
 		scheme = "https"
-	} // todo: ws/wss
+	} else if _, ok = pm[multiaddr.P_HTTP]; ok {
+		// /tls/http == /https
+		if _, ok = pm[multiaddr.P_TLS]; ok {
+			scheme = "https"
+		}
+	} else if _, ok = pm[multiaddr.P_WSS]; ok {
+		scheme = "wss"
+	} else if _, ok = pm[multiaddr.P_WS]; ok {
+		scheme = "ws"
+		// /tls/ws == /wss
+		if _, ok = pm[multiaddr.P_TLS]; ok {
+			scheme = "wss"
+		}
+	}
 
 	path := ""
 	if pb, ok := pm[protoHTTPath.Code]; ok {
@@ -86,9 +99,9 @@ func ToURL(ma multiaddr.Multiaddr) (*url.URL, error) {
 	return &out, nil
 }
 
-// ToMA takes a url and converts it into a multiaddr.
+// ToMultiaddr takes a url and converts it into a multiaddr.
 // converts scheme://host:port/path -> /ip/host/tcp/port/scheme/urlescape{path}
-func ToMA(u *url.URL) (*multiaddr.Multiaddr, error) {
+func ToMultiaddr(u *url.URL) (multiaddr.Multiaddr, error) {
 	h := u.Hostname()
 	var addr *multiaddr.Multiaddr
 	if n := net.ParseIP(h); n != nil {
@@ -130,5 +143,5 @@ func ToMA(u *url.URL) (*multiaddr.Multiaddr, error) {
 		joint = multiaddr.Join(joint, httpath)
 	}
 
-	return &joint, nil
+	return joint, nil
 }

--- a/httpsync/multiaddr/convert_test.go
+++ b/httpsync/multiaddr/convert_test.go
@@ -64,6 +64,9 @@ func TestTLSProtos(t *testing.T) {
 		}
 
 		u, err := ToURL(m)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if u.String() != expect[i] {
 			t.Fatalf("expected %s to convert to url %s, got %s", m.String(), expect[i], u.String())
 		}

--- a/httpsync/multiaddr/convert_test.go
+++ b/httpsync/multiaddr/convert_test.go
@@ -57,7 +57,7 @@ func TestTLSProtos(t *testing.T) {
 		"ws://protocol.ai",
 	}
 
-	for i, _ := range samples {
+	for i := range samples {
 		m, err := multiaddr.NewMultiaddr(samples[i])
 		if err != nil {
 			t.Fatal(err)

--- a/httpsync/multiaddr/convert_test.go
+++ b/httpsync/multiaddr/convert_test.go
@@ -3,6 +3,8 @@ package multiaddr
 import (
 	"net/url"
 	"testing"
+
+	"github.com/multiformats/go-multiaddr"
 )
 
 func TestRoundtrip(t *testing.T) {
@@ -16,11 +18,11 @@ func TestRoundtrip(t *testing.T) {
 
 	for _, s := range samples {
 		u, _ := url.Parse(s)
-		mu, err := ToMA(u)
+		mu, err := ToMultiaddr(u)
 		if err != nil {
 			t.Fatal(err)
 		}
-		u2, err := ToURL(*mu)
+		u2, err := ToURL(mu)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -32,6 +34,38 @@ func TestRoundtrip(t *testing.T) {
 		}
 		if u2.Path != u.Path {
 			t.Fatalf("path didn't roundtrip. got %s, expected %s", u2.Path, u.Path)
+		}
+	}
+}
+
+func TestTLSProtos(t *testing.T) {
+	samples := []string{
+		"/ip4/192.169.0.1/tls/http",
+		"/ip4/192.169.0.1/https",
+		"/ip4/192.169.0.1/http",
+		"/dns4/protocol.ai/tls/ws",
+		"/dns4/protocol.ai/wss",
+		"/dns4/protocol.ai/ws",
+	}
+
+	expect := []string{
+		"https://192.169.0.1",
+		"https://192.169.0.1",
+		"http://192.169.0.1",
+		"wss://protocol.ai",
+		"wss://protocol.ai",
+		"ws://protocol.ai",
+	}
+
+	for i, _ := range samples {
+		m, err := multiaddr.NewMultiaddr(samples[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		u, err := ToURL(m)
+		if u.String() != expect[i] {
+			t.Fatalf("expected %s to convert to url %s, got %s", m.String(), expect[i], u.String())
 		}
 	}
 }


### PR DESCRIPTION
When converting a multiaddr to a URL, "/https" and "/tls/http" should both convert to "https://". Also handle "/wss" and "/tls/ws" similarly.

- Fix: When converting url to multiaddr, return `multiaddr.Multiaddr` interface, not pointer to interface.