### PR TITLE
Option to filter un-routable IP addresses from announce messages

### DIFF
--- a/mautil/mautil.go
+++ b/mautil/mautil.go
@@ -1,0 +1,49 @@
+// Package mautil provider multiaddr utility functions.
+package mautil
+
+import (
+	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+// FilterPrivateIPs returns a new slice of multiaddrs with any private,
+// loopback, or unspecified IP multiaddrs removed. If no multiaddrs are
+// removed, then returns the original slice.
+func FilterPrivateIPs(maddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	var pvt []int
+	for i, maddr := range maddrs {
+		ip, err := manet.ToIP(maddr)
+		if err != nil {
+			continue
+		}
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified() {
+			pvt = append(pvt, i)
+		}
+	}
+
+	// If no private addrs, return original slice.
+	if len(pvt) == 0 {
+		return maddrs
+	}
+
+	// If no non-private addrs, return nothing.
+	notPrivLen := len(maddrs) - len(pvt)
+	if notPrivLen == 0 {
+		return nil
+	}
+
+	// Return new slice with non-private addrs.
+	newAddrs := make([]multiaddr.Multiaddr, 0, notPrivLen)
+	skip := pvt[0]
+	for i, maddr := range maddrs {
+		if i == skip {
+			if len(pvt) > 1 {
+				pvt = pvt[1:]
+				skip = pvt[0]
+			}
+			continue
+		}
+		newAddrs = append(newAddrs, maddr)
+	}
+	return newAddrs
+}

--- a/mautil/mautil_test.go
+++ b/mautil/mautil_test.go
@@ -1,0 +1,42 @@
+package mautil
+
+import (
+	"testing"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+func TestFilterPrivateIPs(t *testing.T) {
+	addrs := []string{
+		"/ip4/10.255.0.0/tcp/443",
+		"/ip4/11.0.0.0/tcp/80",
+		"/ip6/fc00::/tcp/1717",
+		"/ip6/fe00::/tcp/8080",
+		"/ip4/192.168.11.22/tcp/9999",
+		"/dns4/example.net/tcp/1234",
+		"/ip4/127.0.0.1/tcp/9999",
+	}
+	maddrs := make([]multiaddr.Multiaddr, len(addrs))
+	for i := range addrs {
+		var err error
+		maddrs[i], err = multiaddr.NewMultiaddr(addrs[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	expected := make([]multiaddr.Multiaddr, 0, 3)
+	expected = append(expected, maddrs[1])
+	expected = append(expected, maddrs[3])
+	expected = append(expected, maddrs[5])
+
+	filtered := FilterPrivateIPs(maddrs)
+	if len(filtered) != len(expected) {
+		t.Fatalf("wrong number of addrs after filtering, expected %d got %d", len(expected), len(filtered))
+	}
+
+	for i := range filtered {
+		if filtered[i] != expected[i] {
+			t.Fatalf("unexpected multiaddrs %s, expected %s", filtered[i], expected[i])
+		}
+	}
+}

--- a/option.go
+++ b/option.go
@@ -19,6 +19,7 @@ import (
 type config struct {
 	addrTTL   time.Duration
 	allowPeer AllowPeerFunc
+	filterIPs bool
 
 	topic *pubsub.Topic
 
@@ -101,6 +102,15 @@ func HttpClient(client *http.Client) Option {
 func BlockHook(blockHook BlockHookFunc) Option {
 	return func(c *config) error {
 		c.blockHook = blockHook
+		return nil
+	}
+}
+
+// FilterIPs removes any private, loopback, or unspecified IP multiaddrs from
+// addresses supplied in announce messages.
+func FilterIPs(enable bool) Option {
+	return func(c *config) error {
+		c.filterIPs = enable
 		return nil
 	}
 }


### PR DESCRIPTION
Option to filter private, loopback, and unspecified IP addresses from announce messages.