### PR TITLE
fix: respect context cancellation in dtsync Syncer.Sync()

### DIFF
--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -68,7 +68,7 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 		select {
 		case err = <-syncDone:
 		case <-ctx.Done():
-			s.sync.signalSyncDone(inProgressSyncK, nil)
+			s.sync.signalSyncDone(inProgressSyncK, ctx.Err())
 			err = <-syncDone
 		}
 		if err, ok := err.(rateLimitErr); ok {


### PR DESCRIPTION
Context cancellation was not working for me with dtsync, I think this is because even though a context is passed into `OpenPullDataChannel()`, the function is not blocking and is only used for starting the channel, after which point the context no longer has any control over the channel.

The solution I found is to also watch for context cancellation next to syncDone, manually signal sync done if so, and then wait for its error again after.

This change fixed my issue in my project and context cancellation now works as expected.